### PR TITLE
[fix/#128] 검색 쿼리 고침 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ out/
 
 /src/main/resources/local-application.yml
 /src/main/resources/dev-application.yml
+/src/main/generated/*

--- a/build.gradle
+++ b/build.gradle
@@ -57,8 +57,24 @@ dependencies {
 
 	//S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	// querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0' // 쿼리 파라미터 로그 남기기
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+def generated = 'src/main/generated'
+tasks.withType(JavaCompile).configureEach {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+clean {
+	delete file(generated)
 }

--- a/src/main/java/umc/th/juinjang/converter/limjang/LimjangTotalListConverter.java
+++ b/src/main/java/umc/th/juinjang/converter/limjang/LimjangTotalListConverter.java
@@ -47,13 +47,17 @@ public class LimjangTotalListConverter {
 
   public static LimjangListDto toLimjangList(
       Limjang limjang, LimjangPrice limjangPrice, int limitImageListSize) {
-    
+
+    System.out.println("---------------");
+    System.out.println("toLimjangList입니다. 이미지를 찾습니다... ");
     List<String> urlList = limjang.getImageList().stream()
         .sorted(Comparator.comparing(Image::getCreatedAt)) // image를 createdAt 기준으로 정렬
         .map(Image::getImageUrl)
         .limit(limitImageListSize)
         .toList();
 
+    System.out.println("---------------");
+    System.out.println("toLimjangList입니다. Limjangprice 찾습니다... ");
     Integer purposeType = limjang.getPurpose().getValue();
     Integer priceType = limjang.getPriceType().getValue();
     List<String> priceList = makePriceList(priceType, purposeType,limjangPrice);

--- a/src/main/java/umc/th/juinjang/repository/limjang/LimjangQueryDslRepository.java
+++ b/src/main/java/umc/th/juinjang/repository/limjang/LimjangQueryDslRepository.java
@@ -6,6 +6,6 @@ import umc.th.juinjang.model.entity.Member;
 
 public interface LimjangQueryDslRepository {
 
-  List<Limjang> searchLimjangs(Member member, String keyword)
+  List<Limjang> searchLimjangs(Member member, String keyword);
 
 }

--- a/src/main/java/umc/th/juinjang/repository/limjang/LimjangQueryDslRepository.java
+++ b/src/main/java/umc/th/juinjang/repository/limjang/LimjangQueryDslRepository.java
@@ -1,0 +1,11 @@
+package umc.th.juinjang.repository.limjang;
+
+import java.util.List;
+import umc.th.juinjang.model.entity.Limjang;
+import umc.th.juinjang.model.entity.Member;
+
+public interface LimjangQueryDslRepository {
+
+  List<Limjang> searchLimjangs(Member member, String keyword)
+
+}

--- a/src/main/java/umc/th/juinjang/repository/limjang/LimjangQueryDslRepositoryImpl.java
+++ b/src/main/java/umc/th/juinjang/repository/limjang/LimjangQueryDslRepositoryImpl.java
@@ -1,0 +1,47 @@
+package umc.th.juinjang.repository.limjang;
+
+import static umc.th.juinjang.model.entity.QLimjang.*;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import umc.th.juinjang.model.entity.Limjang;
+import umc.th.juinjang.model.entity.Member;
+
+public class LimjangQueryDslRepositoryImpl implements LimjangQueryDslRepository {
+  private final JPAQueryFactory queryFactory;
+
+  public LimjangQueryDslRepositoryImpl(EntityManager em) {
+    this.queryFactory = new JPAQueryFactory(em);
+  }
+
+  @Override
+  public List<Limjang> searchLimjangs(Member member, String keyword) {
+    String pKeyword = "%" + keyword.toLowerCase().replaceAll(" ", "") + "%";
+
+    return queryFactory
+        .selectFrom(limjang)
+        .where(limjang.memberId.eq(member),
+            keywordOf(
+                removeBlank(limjang.nickname).like(pKeyword),
+                removeBlank(limjang.address).like(pKeyword),
+                removeBlank(limjang.addressDetail).like(pKeyword)
+            ))
+        .fetch();
+  }
+
+  private BooleanExpression keywordOf(BooleanExpression... conditions) {
+    BooleanExpression result = null;
+    for (BooleanExpression condition : conditions) {
+      result = result == null ? condition : result.or(condition);
+    }
+    return result;
+  }
+
+  private StringExpression removeBlank(StringExpression origin) {
+      return Expressions.stringTemplate("function('replace', function('lower', {0}), ' ', '')", origin);
+  }
+}

--- a/src/main/java/umc/th/juinjang/repository/limjang/LimjangQueryDslRepositoryImpl.java
+++ b/src/main/java/umc/th/juinjang/repository/limjang/LimjangQueryDslRepositoryImpl.java
@@ -1,7 +1,10 @@
 package umc.th.juinjang.repository.limjang;
 
-import static umc.th.juinjang.model.entity.QLimjang.*;
-
+import static umc.th.juinjang.model.entity.QImage.image;
+import static umc.th.juinjang.model.entity.QLimjang.limjang;
+import static umc.th.juinjang.model.entity.QLimjangPrice.limjangPrice;
+import static umc.th.juinjang.model.entity.QReport.report;
+import static umc.th.juinjang.model.entity.QScrap.scrap;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.StringExpression;
@@ -20,15 +23,19 @@ public class LimjangQueryDslRepositoryImpl implements LimjangQueryDslRepository 
 
   @Override
   public List<Limjang> searchLimjangs(Member member, String keyword) {
-    String pKeyword = "%" + keyword.toLowerCase().replaceAll(" ", "") + "%";
+    String rKeyword = keyword.replaceAll(" ", "");
 
     return queryFactory
         .selectFrom(limjang)
+        .leftJoin(limjang.report, report).fetchJoin()
+        .leftJoin(limjang.scrap, scrap).fetchJoin()
+        .leftJoin(limjang.priceId, limjangPrice).fetchJoin()
+        .leftJoin(limjang.imageList, image).fetchJoin()
         .where(limjang.memberId.eq(member),
             keywordOf(
-                removeBlank(limjang.nickname).like(pKeyword),
-                removeBlank(limjang.address).like(pKeyword),
-                removeBlank(limjang.addressDetail).like(pKeyword)
+                removeBlank(limjang.nickname).containsIgnoreCase(rKeyword),
+                removeBlank(limjang.address).containsIgnoreCase(rKeyword),
+                removeBlank(limjang.addressDetail).containsIgnoreCase(rKeyword)
             ))
         .fetch();
   }
@@ -42,6 +49,6 @@ public class LimjangQueryDslRepositoryImpl implements LimjangQueryDslRepository 
   }
 
   private StringExpression removeBlank(StringExpression origin) {
-      return Expressions.stringTemplate("function('replace', function('lower', {0}), ' ', '')", origin);
+    return Expressions.stringTemplate("function('replace', {0}, ' ', '')", origin);
   }
 }

--- a/src/main/java/umc/th/juinjang/repository/limjang/LimjangRepository.java
+++ b/src/main/java/umc/th/juinjang/repository/limjang/LimjangRepository.java
@@ -14,7 +14,7 @@ import umc.th.juinjang.model.entity.Limjang;
 import umc.th.juinjang.model.entity.Member;
 
 @Repository
-public interface LimjangRepository extends JpaRepository<Limjang, Long> {
+public interface LimjangRepository extends JpaRepository<Limjang, Long>, LimjangQueryDslRepository {
 
   List<Limjang> findLimjangByMemberId(Member member);
 
@@ -29,13 +29,12 @@ public interface LimjangRepository extends JpaRepository<Limjang, Long> {
   // 가장 최근에 update된 5개 순서대로
   List<Limjang> findTop5ByMemberIdOrderByUpdatedAtDesc(Member member);
 
-  @Query("SELECT l FROM Limjang l WHERE " +
-      "l.memberId = :member AND " +
-      "(REPLACE(LOWER(l.nickname), ' ', '') LIKE REPLACE(LOWER(CONCAT('%', :keyword, '%')), ' ', '') OR " +
-      "REPLACE(LOWER(l.address), ' ', '') LIKE REPLACE(LOWER(CONCAT('%', :keyword, '%')), ' ', '') OR " +
-      "REPLACE(LOWER(l.addressDetail), ' ', '') LIKE REPLACE(LOWER(CONCAT('%', :keyword, '%')), ' ', ''))")
-
-  List<Limjang> searchLimjangs(@Param("member") Member member, @Param("keyword") String keyword);
+//  @Query("SELECT l FROM Limjang l WHERE " +
+//      "l.memberId = :member AND " +
+//      "(REPLACE(LOWER(l.nickname), ' ', '') LIKE REPLACE(LOWER(CONCAT('%', :keyword, '%')), ' ', '') OR " +
+//      "REPLACE(LOWER(l.address), ' ', '') LIKE REPLACE(LOWER(CONCAT('%', :keyword, '%')), ' ', '') OR " +
+//      "REPLACE(LOWER(l.addressDetail), ' ', '') LIKE REPLACE(LOWER(CONCAT('%', :keyword, '%')), ' ', ''))")
+//  List<Limjang> searchLimjangs(@Param("member") Member member, @Param("keyword") String keyword);
 
   Optional<Limjang> findLimjangByLimjangIdAndMemberId(Long limjangId, Member member);
 

--- a/src/main/java/umc/th/juinjang/repository/limjang/LimjangRepository.java
+++ b/src/main/java/umc/th/juinjang/repository/limjang/LimjangRepository.java
@@ -29,13 +29,6 @@ public interface LimjangRepository extends JpaRepository<Limjang, Long>, Limjang
   // 가장 최근에 update된 5개 순서대로
   List<Limjang> findTop5ByMemberIdOrderByUpdatedAtDesc(Member member);
 
-//  @Query("SELECT l FROM Limjang l WHERE " +
-//      "l.memberId = :member AND " +
-//      "(REPLACE(LOWER(l.nickname), ' ', '') LIKE REPLACE(LOWER(CONCAT('%', :keyword, '%')), ' ', '') OR " +
-//      "REPLACE(LOWER(l.address), ' ', '') LIKE REPLACE(LOWER(CONCAT('%', :keyword, '%')), ' ', '') OR " +
-//      "REPLACE(LOWER(l.addressDetail), ' ', '') LIKE REPLACE(LOWER(CONCAT('%', :keyword, '%')), ' ', ''))")
-//  List<Limjang> searchLimjangs(@Param("member") Member member, @Param("keyword") String keyword);
-
   Optional<Limjang> findLimjangByLimjangIdAndMemberId(Long limjangId, Member member);
 
   @Modifying

--- a/src/main/java/umc/th/juinjang/service/LimjangService/LimjangQueryServiceImpl.java
+++ b/src/main/java/umc/th/juinjang/service/LimjangService/LimjangQueryServiceImpl.java
@@ -105,12 +105,7 @@ public class LimjangQueryServiceImpl implements LimjangQueryService{
     Member findMember = memberRepository.findById(1L)
         .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
-    List<Limjang> findLimjangListByKeyword = limjangRepository.searchLimjangs(findMember, keyword).stream().peek(
-        limjang -> {
-          Report report = reportRepository.findByLimjangId(limjang).orElse(null);
-          limjang.saveReport(report);
-        }
-    ).toList();
+    List<Limjang> findLimjangListByKeyword = limjangRepository.searchLimjangs(findMember, keyword).stream().toList();
 
     return LimjangTotalListConverter.toLimjangTotalList(findLimjangListByKeyword);
   }

--- a/src/test/java/umc/th/juinjang/limjang/LimjangSearchTest.java
+++ b/src/test/java/umc/th/juinjang/limjang/LimjangSearchTest.java
@@ -1,5 +1,0 @@
-package umc.th.juinjang.limjang;
-
-public class LimjangSearchTest {
-
-}

--- a/src/test/java/umc/th/juinjang/limjang/LimjangSearchTest.java
+++ b/src/test/java/umc/th/juinjang/limjang/LimjangSearchTest.java
@@ -1,0 +1,5 @@
+package umc.th.juinjang.limjang;
+
+public class LimjangSearchTest {
+
+}


### PR DESCRIPTION
## 작업내용

검색 쿼리를 querydsl로 고쳤습니다.

## 상세설명_ & 캡쳐

- 기존 service, converter도 리팩토링했습니다.
- 불필요한 쿼리가 많이 나가서 아래처럼 scrap, limjangPrice, Image, report의 경우 쿼리에서 fetch join으로 한번에 가져오게 바꿨습니다. 
```java
.leftJoin(limjang.report, report).fetchJoin()
        .leftJoin(limjang.scrap, scrap).fetchJoin()
        .leftJoin(limjang.priceId, limjangPrice).fetchJoin()
        .leftJoin(limjang.imageList, image).fetchJoin()
```
- 스웨거랑 로컬 DB에서 스크랩 & 이미지들어간 게시글 테스트 완료했습니다
- 검색 쿼리도 점검했습니다
```mysql
select
    l1_0.limjang_id,
    l1_0.address,
    l1_0.address_detail,
    l1_0.created_at,
    l1_0.deleted,
    il1_0.limjang_id,
    il1_0.image_id,
    il1_0.created_at,
    il1_0.image_url,
    il1_0.updated_at,
    l1_0.member_id,
    l1_0.memo,
    l1_0.nickname,
    pi1_0.price_id,
    pi1_0.created_at,
    pi1_0.deposit_price,
    pi1_0.market_price,
    pi1_0.monthly_rent,
    pi1_0.pull_rent,
    pi1_0.selling_price,
    pi1_0.updated_at,
    l1_0.price_type,
    l1_0.property_type,
    l1_0.purpose,
    l1_0.record_count,
    r1_0.report_id,
    r1_0.created_at,
    r1_0.indoor_keyword,
    r1_0.indoor_rate,
    r1_0.location_conditions_keyword,
    r1_0.location_conditions_rate,
    r1_0.public_space_keyword,
    r1_0.public_space_rate,
    r1_0.total_rate,
    r1_0.updated_at,
    s1_0.scrap_id,
    s1_0.created_at,
    s1_0.updated_at,
    l1_0.updated_at
from
    limjang l1_0
left join
    report r1_0
        on l1_0.limjang_id=r1_0.limjang_id
left join
    scrap s1_0
        on l1_0.limjang_id=s1_0.limjang_id
left join
    limjang_price pi1_0
        on pi1_0.price_id=l1_0.price_id
left join
    image il1_0
        on l1_0.limjang_id=il1_0.limjang_id
where
    (
        l1_0.deleted = false
    )
    and l1_0.member_id=?
    and (
        lower(replace(l1_0.nickname, ' ', '')) like ? escape '!'
        or lower(replace(l1_0.address, ' ', '')) like ? escape '!'
        or lower(replace(l1_0.address_detail, ' ', '')) like ? escape '!'
    )

```

'test'로 검색했을경우
```mysql
select l1_0.limjang_id,l1_0.address,l1_0.address_detail,l1_0.created_at,l1_0.deleted,il1_0.limjang_id,il1_0.image_id,il1_0.created_at,il1_0.image_url,il1_0.updated_at,l1_0.member_id,l1_0.memo,l1_0.nickname,pi1_0.price_id,pi1_0.created_at,pi1_0.deposit_price,pi1_0.market_price,pi1_0.monthly_rent,pi1_0.pull_rent,pi1_0.selling_price,pi1_0.updated_at,l1_0.price_type,l1_0.property_type,l1_0.purpose,l1_0.record_count,r1_0.report_id,r1_0.created_at,r1_0.indoor_keyword,r1_0.indoor_rate,r1_0.location_conditions_keyword,r1_0.location_conditions_rate,r1_0.public_space_keyword,r1_0.public_space_rate,r1_0.total_rate,r1_0.updated_at,s1_0.scrap_id,s1_0.created_at,s1_0.updated_at,l1_0.updated_at 
from limjang l1_0 left join report r1_0 on l1_0.limjang_id=r1_0.limjang_id left join scrap s1_0 on l1_0.limjang_id=s1_0.limjang_id left join limjang_price pi1_0 on pi1_0.price_id=l1_0.price_id left join image il1_0 on l1_0.limjang_id=il1_0.limjang_id 
where (l1_0.deleted = false) and l1_0.member_id=1 and (lower(replace(l1_0.nickname,' ','')) like '%test%' escape '!' or lower(replace(l1_0.address,' ','')) like '%test%' escape '!' or lower(replace(l1_0.address_detail,' ','')) like '%test%' escape '!');
```