### PR TITLE
refactor: update jpa to native query(#223)

### DIFF
--- a/src/main/java/umc/th/juinjang/repository/checklist/ReportRepository.java
+++ b/src/main/java/umc/th/juinjang/repository/checklist/ReportRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
     Optional<Report> findByLimjangId(Limjang limjang);
+
+    void deleteAllByLimjangId(Limjang limjang);
 }

--- a/src/main/java/umc/th/juinjang/repository/image/ImageRepository.java
+++ b/src/main/java/umc/th/juinjang/repository/image/ImageRepository.java
@@ -10,4 +10,6 @@ import umc.th.juinjang.model.entity.Record;
 public interface ImageRepository extends JpaRepository<Image, Long> {
 
   List<Image> findImagesByLimjangId(Limjang limjang);
+
+    void deleteAllByLimjangId(Limjang limjang);
 }

--- a/src/main/java/umc/th/juinjang/repository/limjang/LimjangRepository.java
+++ b/src/main/java/umc/th/juinjang/repository/limjang/LimjangRepository.java
@@ -16,7 +16,9 @@ import umc.th.juinjang.model.entity.Member;
 @Repository
 public interface LimjangRepository extends JpaRepository<Limjang, Long>, LimjangQueryDslRepository {
 
-  List<Limjang> findLimjangByMemberId(Member member);
+
+  @Query(value = "SELECT * FROM limjang l WHERE l.member_id = :memberId", nativeQuery = true)
+  List<Limjang> findLimjangByMemberIdIgnoreDeleted(@Param("memberId") Long memberId);
 
   @Modifying
   @Query("UPDATE Limjang l SET l.deleted = true, l.updatedAt = CURRENT_TIMESTAMP WHERE l.limjangId = :limjangId")
@@ -41,6 +43,10 @@ public interface LimjangRepository extends JpaRepository<Limjang, Long>, Limjang
   @Query("UPDATE Limjang l SET l.memo = :memo WHERE l.limjangId = :limjangId")
   void updateMemo(@Param("limjangId") Long limjangId, @Param("memo") String memo);
 
+  @Transactional
+  @Modifying
+  @Query(value = "DELETE FROM limjang l WHERE l.member_id = :memberId", nativeQuery = true)
+  void deleteAllByMemberId(@Param("memberId") Long memberId);
 
 //  void deleteByMember(Member member);
 }

--- a/src/main/java/umc/th/juinjang/repository/limjang/ScrapRepository.java
+++ b/src/main/java/umc/th/juinjang/repository/limjang/ScrapRepository.java
@@ -18,4 +18,6 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
   @Modifying
   @Query("delete from Scrap s where s.scrapId = :id")
   void deleteByScrapId(@Param("id")long id);
+
+  void deleteByLimjangId(Limjang limjang);
 }

--- a/src/main/java/umc/th/juinjang/repository/record/RecordRepository.java
+++ b/src/main/java/umc/th/juinjang/repository/record/RecordRepository.java
@@ -18,4 +18,5 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
     public List<Record> findTop3ByLimjangIdOrderByRecordIdDesc(Limjang limjang);
 
 
+    void deleteAllByLimjangId(Limjang limjang);
 }


### PR DESCRIPTION
## 작업내용

jpql을 native query로 변경

## 상세설명_ & 캡쳐

@Where이 적용되었기 때문에 jpql을 사용하면 자동으로 조건이 추가되어 쿼리가 나감
따라서 native query를 사용해 이를 해결함

우려되는 점은 native query 사용으로 인해 특정 데이터베이스에 종속적이기 때문에, 애플리케이션을 다른 데이터베이스로 마이그레이션할 때 문제가 발생 할 수도 있음