### PR TITLE
[feat/#268] 디스코드 알림 전송 이벤트 퍼블리셔 방식으로 변경

### DIFF
--- a/src/main/java/umc/th/juinjang/JuinjangApplication.java
+++ b/src/main/java/umc/th/juinjang/JuinjangApplication.java
@@ -6,10 +6,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableAsync
 @ImportAutoConfiguration({FeignAutoConfiguration.class})
 public class JuinjangApplication {
 

--- a/src/main/java/umc/th/juinjang/event/SignUpEvent.java
+++ b/src/main/java/umc/th/juinjang/event/SignUpEvent.java
@@ -1,0 +1,13 @@
+package umc.th.juinjang.event;
+
+import umc.th.juinjang.model.entity.enums.MemberProvider;
+
+public record SignUpEvent(
+    MemberProvider memberProvider,
+    String name,
+    long count
+) {
+  public static SignUpEvent of(MemberProvider memberProvider, String name, long count) {
+    return new SignUpEvent(memberProvider, name, count);
+  }
+}

--- a/src/main/java/umc/th/juinjang/event/publisher/ApplicationMemberEventPublisherAdapter.java
+++ b/src/main/java/umc/th/juinjang/event/publisher/ApplicationMemberEventPublisherAdapter.java
@@ -1,0 +1,19 @@
+package umc.th.juinjang.event.publisher;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import umc.th.juinjang.event.SignUpEvent;
+import umc.th.juinjang.model.entity.Member;
+
+@RequiredArgsConstructor
+@Component
+public class ApplicationMemberEventPublisherAdapter implements MemberEventPublisher {
+
+  private final ApplicationEventPublisher applicationEventPublisher;
+
+  @Override
+  public void publishSignUpEvent(Member member) {
+    applicationEventPublisher.publishEvent(SignUpEvent.of(member.getProvider(), member.getNickname(), member.getMemberId()));
+  }
+}

--- a/src/main/java/umc/th/juinjang/event/publisher/MemberEventPublisher.java
+++ b/src/main/java/umc/th/juinjang/event/publisher/MemberEventPublisher.java
@@ -1,0 +1,7 @@
+package umc.th.juinjang.event.publisher;
+
+import umc.th.juinjang.model.entity.Member;
+
+public interface MemberEventPublisher {
+  void publishSignUpEvent(Member member);
+}

--- a/src/main/java/umc/th/juinjang/event/subscriber/DiscordEventListener.java
+++ b/src/main/java/umc/th/juinjang/event/subscriber/DiscordEventListener.java
@@ -1,0 +1,31 @@
+package umc.th.juinjang.event.subscriber;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import umc.th.juinjang.event.SignUpEvent;
+import umc.th.juinjang.external.discord.DiscordAlertProvider;
+
+@Component
+@RequiredArgsConstructor
+public class DiscordEventListener {
+
+  private final DiscordAlertProvider discordAlertProvider;
+  private final Environment environment;
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  @Async
+  public void handleSignUpEvent (SignUpEvent event){
+    if (isProdEnv()) {
+      discordAlertProvider.sendAlertToDiscord(String.format(EventMessage.SIGN_UP_MESSAGE.getMessage(), event.memberProvider(), event.count(), event.name()));
+    }
+  }
+
+  private boolean isProdEnv() {
+    return environment.acceptsProfiles(Profiles.of("prod"));
+  }
+}

--- a/src/main/java/umc/th/juinjang/event/subscriber/EventMessage.java
+++ b/src/main/java/umc/th/juinjang/event/subscriber/EventMessage.java
@@ -1,0 +1,13 @@
+package umc.th.juinjang.event.subscriber;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public enum EventMessage {
+  SIGN_UP_MESSAGE("주인장에 %s %d번째 유저 < %s >님이 생겼어요!");
+
+  private final String message;
+}

--- a/src/main/java/umc/th/juinjang/external/discord/DiscordAlertProvider.java
+++ b/src/main/java/umc/th/juinjang/external/discord/DiscordAlertProvider.java
@@ -1,14 +1,10 @@
 package umc.th.juinjang.external.discord;
 
 import feign.FeignException;
-import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
-import umc.th.juinjang.apiPayload.code.status.ErrorStatus;
 import umc.th.juinjang.external.discord.dto.DiscordAlert;
-import umc.th.juinjang.model.entity.Member;
 
 @RequiredArgsConstructor
 @Component
@@ -16,19 +12,12 @@ import umc.th.juinjang.model.entity.Member;
 public class DiscordAlertProvider {
 
   private final DiscordFeignClient discordFeignClient;
-  private final Environment environment;
 
-  public void sendAlert(Member member) {
-    if (Arrays.asList(environment.getActiveProfiles()).contains("prod")) {
-      sendAlertToDiscord(DiscordAlert.createAlert(member.getMemberId(), member.getProvider(), member.getNickname()));
-    }
-  }
-
-  private void sendAlertToDiscord(DiscordAlert discordAlert) {
+  public void sendAlertToDiscord(String content) {
     try {
-      discordFeignClient.sendAlert(discordAlert);
+      discordFeignClient.sendAlert(DiscordAlert.createAlert(content));
     } catch (FeignException e) {
-      log.info(ErrorStatus.DISCORD_ALERT_ERROR.getMessage()+ " " +e.getMessage());
+      log.info(StatusMessage.DISCORD_ALERT_ERROR.getMessage()+ " " +e.getMessage());
     }
   }
 }

--- a/src/main/java/umc/th/juinjang/external/discord/StatusMessage.java
+++ b/src/main/java/umc/th/juinjang/external/discord/StatusMessage.java
@@ -1,0 +1,14 @@
+package umc.th.juinjang.external.discord;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum StatusMessage {
+  DISCORD_ALERT_ERROR("discord 알림 수신 중 오류가 발생했습니다."),
+  DISCORD_ALERT_SUCCESS("discord 알림 수신 성공했습니다.");
+
+  private final String message;
+}

--- a/src/main/java/umc/th/juinjang/external/discord/dto/DiscordAlert.java
+++ b/src/main/java/umc/th/juinjang/external/discord/dto/DiscordAlert.java
@@ -1,9 +1,7 @@
 package umc.th.juinjang.external.discord.dto;
 
-import umc.th.juinjang.model.entity.enums.MemberProvider;
-
 public record DiscordAlert(String content) {
-  public static DiscordAlert createAlert(Long id, MemberProvider memberProvider, String nickname) {
-    return new DiscordAlert("주인장에 " +memberProvider+" "+id+"번째 유저 < "+nickname+" >님이 생겼어요!");
+  public static DiscordAlert createAlert(String content) {
+    return new DiscordAlert(content);
   }
 }

--- a/src/main/java/umc/th/juinjang/service/auth/OAuthService.java
+++ b/src/main/java/umc/th/juinjang/service/auth/OAuthService.java
@@ -10,7 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import umc.th.juinjang.apiPayload.ExceptionHandler;
 import umc.th.juinjang.apiPayload.exception.handler.MemberHandler;
 import umc.th.juinjang.controller.KakaoUnlinkClient;
-import umc.th.juinjang.external.discord.DiscordAlertProvider;
+import umc.th.juinjang.event.publisher.MemberEventPublisher;
 import umc.th.juinjang.model.dto.auth.LoginResponseDto;
 import umc.th.juinjang.model.dto.auth.TokenDto;
 import umc.th.juinjang.model.dto.auth.apple.*;
@@ -50,7 +50,6 @@ public class OAuthService {
     private final JwtService jwtService;
     private final AppleClientSecretGenerator appleClientSecretGenerator;
     private final AppleOAuthProvider appleOAuthProvider;
-    private final DiscordAlertProvider discordAlertProvider;
     private final ScrapRepository scrapRepository;
     private final LimjangRepository limjangRepository;
     private final ChecklistAnswerRepository checklistAnswerRepository;
@@ -59,6 +58,7 @@ public class OAuthService {
     private final ReportRepository reportRepository;
     private final S3Service s3Service;
     private final LimjangPriceRepository limjangPriceRepository;
+    private final MemberEventPublisher memberEventPublisher;
 
     @Autowired
     private KakaoUnlinkClient kakaoUnlinkClient;
@@ -151,8 +151,12 @@ public class OAuthService {
         }
 
         // accessToken, refreshToken 발급 후 반환
-        discordAlertProvider.sendAlert(member);
+        publishDiscordAlert(member);
         return createToken(member);
+    }
+
+    private void publishDiscordAlert(Member member) {
+        memberEventPublisher.publishSignUpEvent(member);
     }
 
     // accessToken, refreshToken 발급
@@ -300,7 +304,7 @@ public class OAuthService {
         if(member == null)
             throw new MemberHandler(FAILED_TO_LOGIN);
 
-        discordAlertProvider.sendAlert(member);
+        publishDiscordAlert(member);
         return createToken(member);
     }
 


### PR DESCRIPTION
## 작업내용

디스코드 알림 전송 이벤트 퍼블리셔 방식으로 변경

## 상세설명_ & 캡쳐

- 비동기 & 트랜잭션 커밋 보장의 이유로 이벤트 퍼블리셔 방식으로 변경하였습니다. 
