### PR TITLE
[feat/#319] 임장 수정 API 구현

### DIFF
--- a/src/main/java/umc/th/juinjang/api/limjang/controller/NoteControllerV2.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/controller/NoteControllerV2.java
@@ -1,6 +1,8 @@
 package umc.th.juinjang.api.limjang.controller;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import umc.th.juinjang.api.dto.ApiResponse;
+import umc.th.juinjang.api.limjang.controller.request.NotePatchRequest;
 import umc.th.juinjang.api.limjang.controller.request.NotePostRequest;
 import umc.th.juinjang.api.limjang.service.NoteCommandServiceV2;
 import umc.th.juinjang.common.code.status.SuccessStatus;
@@ -24,9 +27,18 @@ public class NoteControllerV2 {
 
 	@Operation(summary = "임장 생성 API V2")
 	@PostMapping
-	public ApiResponse<Void> createNotes(@RequestBody @Valid NotePostRequest request,
+	public ApiResponse<Void> createNote(@RequestBody @Valid NotePostRequest request,
 		@AuthenticationPrincipal Member member) {
 		noteCommandService.createNote(request, member);
 		return ApiResponse.of(SuccessStatus._CREATED, null);
+	}
+
+	@Operation(summary = "임장 수정 API V2")
+	@PatchMapping("/{noteId}")
+	public ApiResponse<Void> updateNote(@PathVariable(name = "noteId") Long noteId,
+		@RequestBody @Valid NotePatchRequest request,
+		@AuthenticationPrincipal Member member) {
+		noteCommandService.updateNote(noteId, request);
+		return ApiResponse.onSuccess(null);
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/limjang/controller/request/NotePatchRequest.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/controller/request/NotePatchRequest.java
@@ -1,0 +1,44 @@
+package umc.th.juinjang.api.limjang.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import umc.th.juinjang.domain.limjang.model.Address;
+import umc.th.juinjang.domain.limjang.model.LimjangPrice;
+import umc.th.juinjang.domain.limjang.model.LimjangPriceType;
+import umc.th.juinjang.domain.limjang.model.LimjangPropertyType;
+import umc.th.juinjang.domain.limjang.model.LimjangPurpose;
+import umc.th.juinjang.domain.limjang.repository.NotePriceFactory;
+
+public record NotePatchRequest(
+	@NotNull
+	LimjangPriceType priceType,
+	@NotBlank
+	@Pattern(regexp = "^[0-9]+$", message = "가격은 숫자만 입력해야 합니다.")
+	String price,
+	@Pattern(regexp = "^[0-9]+$", message = "가격은 숫자만 입력해야 합니다.")
+	String monthlyRent,
+	@NotBlank
+	String roadAddress,
+	String addressDetail,
+	@NotBlank
+	String bcode,
+	@NotBlank
+	String nickname,
+	@NotBlank
+	String floor,
+	int pyong,
+	String sido,
+	String sigungu,
+	String bname1,
+	String bname2
+) {
+
+	public LimjangPrice toUpdatedPrice(LimjangPurpose purpose) {
+		return NotePriceFactory.create(purpose, priceType, price, monthlyRent);
+	}
+
+	public Address toUpdatedAddress() {
+		return Address.create(roadAddress, addressDetail, bcode, sido, sigungu, bname1, bname2);
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/limjang/controller/request/NotePostRequest.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/controller/request/NotePostRequest.java
@@ -3,9 +3,16 @@ package umc.th.juinjang.api.limjang.controller.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import umc.th.juinjang.common.code.status.ErrorStatus;
+import umc.th.juinjang.common.exception.handler.LimjangHandler;
+import umc.th.juinjang.domain.limjang.model.Address;
+import umc.th.juinjang.domain.limjang.model.Limjang;
+import umc.th.juinjang.domain.limjang.model.LimjangPrice;
 import umc.th.juinjang.domain.limjang.model.LimjangPriceType;
 import umc.th.juinjang.domain.limjang.model.LimjangPropertyType;
 import umc.th.juinjang.domain.limjang.model.LimjangPurpose;
+import umc.th.juinjang.domain.limjang.repository.NotePriceFactory;
+import umc.th.juinjang.domain.member.model.Member;
 
 public record NotePostRequest(
 	@NotNull
@@ -34,4 +41,11 @@ public record NotePostRequest(
 	String bname1,
 	String bname2
 ) {
+	public Limjang toEntity(Member member) {
+		LimjangPrice limjangPrice = NotePriceFactory.create(purposeType, priceType, price, monthlyRent);
+		Address address = Address.create(roadAddress, addressDetail, bcode, sido, sigungu, bname1, bname2);
+
+		return Limjang.create(member, limjangPrice, purposeType, propertyType, priceType, nickname, address, pyong,
+			floor);
+	}
 }

--- a/src/main/java/umc/th/juinjang/api/limjang/service/NoteCommandServiceV2.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/service/NoteCommandServiceV2.java
@@ -1,14 +1,19 @@
 package umc.th.juinjang.api.limjang.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.api.limjang.controller.request.NotePatchRequest;
 import umc.th.juinjang.api.limjang.controller.request.NotePostRequest;
 import umc.th.juinjang.api.address.service.AddressUpdater;
+import umc.th.juinjang.common.code.status.ErrorStatus;
+import umc.th.juinjang.common.exception.handler.LimjangHandler;
 import umc.th.juinjang.domain.limjang.model.Address;
 import umc.th.juinjang.domain.limjang.model.Limjang;
 import umc.th.juinjang.domain.limjang.model.LimjangPrice;
-import umc.th.juinjang.domain.limjang.repository.NotePriceFactory;
+import umc.th.juinjang.domain.limjang.model.LimjangPriceType;
+import umc.th.juinjang.domain.limjang.model.LimjangPurpose;
 import umc.th.juinjang.domain.member.model.Member;
 
 @Service
@@ -18,28 +23,39 @@ public class NoteCommandServiceV2 {
 	private final AddressUpdater addressUpdater;
 	private final NoteUpdater noteUpdater;
 	private final NotePriceUpdater notePriceUpdater;
+	private final NoteFinder noteFinder;
 
+	@Transactional
 	public void createNote(NotePostRequest request, Member member) {
-		LimjangPrice limjangPrice = createNotePrice(request);
-		notePriceUpdater.save(limjangPrice);
+		Limjang note = request.toEntity(member);
 
-		Address address = createAddress(request);
-		addressUpdater.save(address);
+		validatePriceType(request.purposeType(), request.priceType());
 
-		Limjang limjang = Limjang.create(member, limjangPrice, request.purposeType(), request.propertyType(),
-			request.priceType(), request.nickname(), address, request.pyong(), request.floor());
-
-		noteUpdater.save(limjang);
+		notePriceUpdater.save(note.getLimjangPrice());
+		addressUpdater.save(note.getAddressEntity());
+		noteUpdater.save(note);
 	}
 
-	private LimjangPrice createNotePrice(NotePostRequest request) {
-		return NotePriceFactory.create(request.purposeType(), request.priceType(),
-			request.price(), request.monthlyRent());
+	@Transactional
+	public void updateNote(Long noteId, NotePatchRequest request) {
+		Limjang note = noteFinder.getNoteByIdWithAddressAndNotePriceWhereDeletedIsFalse(noteId);
+
+		validatePriceType(note.getPurpose(), request.priceType());
+
+		LimjangPrice newPrice = request.toUpdatedPrice(note.getPurpose());
+		Address newAddress = request.toUpdatedAddress();
+
+		note.getAddressEntity().update(newAddress);
+		note.getLimjangPrice().updateLimjangPrice(newPrice);
+		note.updateNote(request.nickname(), request.priceType(), request.floor(), request.pyong());
 	}
 
-	private Address createAddress(NotePostRequest request) {
-		return Address.create(request.roadAddress(), request.addressDetail(), request.bcode(),
-			request.sido(), request.sigungu(),
-			request.bname1(), request.bname2());
+	private void validatePriceType(LimjangPurpose purposeType, LimjangPriceType priceType) {
+		if (
+			(purposeType == LimjangPurpose.RESIDENTIAL_PURPOSE && priceType == LimjangPriceType.MARKET_PRICE) ||
+				(purposeType == LimjangPurpose.INVESTMENT && priceType != LimjangPriceType.MARKET_PRICE)
+		) {
+			throw new LimjangHandler(ErrorStatus.LIMJANG_POST_TYPE_ERROR);
+		}
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/limjang/service/NoteFinder.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/service/NoteFinder.java
@@ -1,0 +1,26 @@
+package umc.th.juinjang.api.limjang.service;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.common.code.status.ErrorStatus;
+import umc.th.juinjang.common.exception.handler.LimjangHandler;
+import umc.th.juinjang.domain.limjang.model.Limjang;
+import umc.th.juinjang.domain.limjang.repository.LimjangRepository;
+
+@Component
+@RequiredArgsConstructor
+public class NoteFinder {
+
+	private final LimjangRepository limjangRepository;
+
+	protected Limjang getNoteByIdWhereDeletedIsFalse(long id) {
+		return limjangRepository.findByLimjangIdAndDeletedIsFalse(id)
+			.orElseThrow(() -> new LimjangHandler(ErrorStatus.LIMJANG_NOTFOUND_ERROR));
+	}
+
+	protected Limjang getNoteByIdWithAddressAndNotePriceWhereDeletedIsFalse(long id) {
+		return limjangRepository.findNoteByIdWithAddressAndNotePriceWhereDeletedIsFalse(id)
+			.orElseThrow(() -> new LimjangHandler(ErrorStatus.LIMJANG_NOTFOUND_ERROR));
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/limjang/service/NoteFinder.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/service/NoteFinder.java
@@ -20,7 +20,7 @@ public class NoteFinder {
 	}
 
 	protected Limjang getNoteByIdWithAddressAndNotePriceWhereDeletedIsFalse(long id) {
-		return limjangRepository.findNoteByIdWithAddressAndNotePriceWhereDeletedIsFalse(id)
+		return limjangRepository.findByIdWithAddressAndNotePriceWhereDeletedIsFalse(id)
 			.orElseThrow(() -> new LimjangHandler(ErrorStatus.LIMJANG_NOTFOUND_ERROR));
 	}
 }

--- a/src/main/java/umc/th/juinjang/domain/limjang/model/Address.java
+++ b/src/main/java/umc/th/juinjang/domain/limjang/model/Address.java
@@ -63,4 +63,14 @@ public class Address extends BaseEntity {
 			.bname2(bname2)
 			.build();
 	}
+
+	public void update(Address newAddress) {
+		this.roadAddress = newAddress.roadAddress;
+		this.addressDetail = newAddress.addressDetail;
+		this.bcode = newAddress.bcode;
+		this.sido = newAddress.sido;
+		this.sigungo = newAddress.sigungo;
+		this.bname1 = newAddress.bname1;
+		this.bname2 = newAddress.bname2;
+	}
 }

--- a/src/main/java/umc/th/juinjang/domain/limjang/model/Limjang.java
+++ b/src/main/java/umc/th/juinjang/domain/limjang/model/Limjang.java
@@ -166,4 +166,11 @@ public class Limjang extends BaseEntity {
 			.floor(floor)
 			.build();
 	}
+
+	public void updateNote(String nickname, LimjangPriceType limjangPriceType, String floor, int pyong) {
+		this.nickname = nickname;
+		this.priceType = limjangPriceType;
+		this.floor = floor;
+		this.pyong = pyong;
+	}
 }

--- a/src/main/java/umc/th/juinjang/domain/limjang/model/LimjangPriceType.java
+++ b/src/main/java/umc/th/juinjang/domain/limjang/model/LimjangPriceType.java
@@ -1,32 +1,32 @@
 package umc.th.juinjang.domain.limjang.model;
 
 import java.util.Arrays;
+
 import umc.th.juinjang.common.code.status.ErrorStatus;
 import umc.th.juinjang.common.exception.handler.LimjangHandler;
 
 public enum LimjangPriceType {
-  SALE(0), // 매매
-  PULL_RENT(1), // 전세
-  MONTHLY_RENT(2), //월세
+	SALE(0), // 매매
+	PULL_RENT(1), // 전세
+	MONTHLY_RENT(2), //월세
+	MARKET_PRICE(3); // 실거래가
 
-  MARKET_PRICE(3); // 실거래가
+	private final int value;
 
+	LimjangPriceType(int value) {
+		this.value = value;
+	}
 
-  private final int value;
+	// 숫자 리턴
+	public int getValue() {
+		return value;
+	}
 
-  LimjangPriceType(int value) {
-    this.value = value;
-  }
+	public static LimjangPriceType find(int inputValue) {
+		return Arrays.stream(LimjangPriceType.values())
+			.filter(it -> it.value == inputValue)
+			.findAny()
+			.orElseThrow(() -> new LimjangHandler(ErrorStatus.LIMJANG_POST_TYPE_ERROR));
+	}
 
-  // 숫자 리턴
-  public int getValue() {
-    return value;
-  }
-
-  public static LimjangPriceType find(int inputValue) {
-    return Arrays.stream(LimjangPriceType.values())
-        .filter(it -> it.value == inputValue)
-        .findAny()
-        .orElseThrow(() -> new LimjangHandler(ErrorStatus.LIMJANG_POST_TYPE_ERROR));
-  }
 }

--- a/src/main/java/umc/th/juinjang/domain/limjang/repository/LimjangRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/limjang/repository/LimjangRepository.java
@@ -58,6 +58,6 @@ public interface LimjangRepository extends JpaRepository<Limjang, Long>, Limjang
 	Optional<Limjang> findByLimjangIdAndDeletedIsFalse(@Param("id") Long id);
 
 	@Query("SELECT l FROM Limjang l join fetch l.addressEntity join fetch l.limjangPrice WHERE l.limjangId = :id AND l.deleted = false")
-	Optional<Limjang> findNoteByIdWithAddressAndNotePriceWhereDeletedIsFalse(@Param("id") Long id);
+	Optional<Limjang> findByIdWithAddressAndNotePriceWhereDeletedIsFalse(@Param("id") Long id);
 
 }

--- a/src/main/java/umc/th/juinjang/domain/limjang/repository/LimjangRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/limjang/repository/LimjangRepository.java
@@ -3,54 +3,61 @@ package umc.th.juinjang.domain.limjang.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
+
 import umc.th.juinjang.domain.limjang.model.Limjang;
 import umc.th.juinjang.domain.member.model.Member;
 
 @Repository
 public interface LimjangRepository extends JpaRepository<Limjang, Long>, LimjangQueryDslRepository {
 
-  @Query(value = "SELECT * FROM limjang l WHERE l.member_id = :memberId", nativeQuery = true)
-  List<Limjang> findLimjangByMemberIdIgnoreDeleted(@Param("memberId") Long memberId);
+	@Query(value = "SELECT * FROM limjang l WHERE l.member_id = :memberId", nativeQuery = true)
+	List<Limjang> findLimjangByMemberIdIgnoreDeleted(@Param("memberId") Long memberId);
 
-  List<Limjang> findAllByLimjangIdInAndMemberIdAndDeletedIsFalse(List<Long> id, Member member);
+	List<Limjang> findAllByLimjangIdInAndMemberIdAndDeletedIsFalse(List<Long> id, Member member);
 
-  @Modifying
-  @Query("UPDATE Limjang l SET l.deleted = true WHERE l.limjangId in :ids")
-  void softDeleteByIds(@Param("ids") List<Long> ids);
+	@Modifying
+	@Query("UPDATE Limjang l SET l.deleted = true WHERE l.limjangId in :ids")
+	void softDeleteByIds(@Param("ids") List<Long> ids);
 
-  @Modifying
-  @Query(value = "DELETE FROM limjang l WHERE l.deleted = true AND l.updated_at < :dateTime", nativeQuery = true)
-  void hardDelete(@Param("dateTime") LocalDateTime dateTime);
+	@Modifying
+	@Query(value = "DELETE FROM limjang l WHERE l.deleted = true AND l.updated_at < :dateTime", nativeQuery = true)
+	void hardDelete(@Param("dateTime") LocalDateTime dateTime);
 
-  Optional<Limjang> findLimjangByLimjangIdAndMemberIdAndDeletedIsFalse(Long limjangId, Member member);
+	Optional<Limjang> findLimjangByLimjangIdAndMemberIdAndDeletedIsFalse(Long limjangId, Member member);
 
-  @Modifying
-  @Transactional
-  @Query("UPDATE Limjang l SET l.recordCount = l.recordCount + 1 WHERE l.limjangId = :limjangId")
-  void incrementRecordCount(@Param("limjangId") Long limjangId);
+	@Modifying
+	@Transactional
+	@Query("UPDATE Limjang l SET l.recordCount = l.recordCount + 1 WHERE l.limjangId = :limjangId")
+	void incrementRecordCount(@Param("limjangId") Long limjangId);
 
-  @Modifying
-  @Transactional
-  @Query("UPDATE Limjang l SET l.memo = :memo WHERE l.limjangId = :limjangId")
-  void updateMemo(@Param("limjangId") Long limjangId, @Param("memo") String memo);
+	@Modifying
+	@Transactional
+	@Query("UPDATE Limjang l SET l.memo = :memo WHERE l.limjangId = :limjangId")
+	void updateMemo(@Param("limjangId") Long limjangId, @Param("memo") String memo);
 
-  @Transactional
-  @Modifying
-  @Query(value = "DELETE FROM limjang l WHERE l.member_id = :memberId", nativeQuery = true)
-  void deleteAllByMemberId(@Param("memberId") Long memberId);
+	@Transactional
+	@Modifying
+	@Query(value = "DELETE FROM limjang l WHERE l.member_id = :memberId", nativeQuery = true)
+	void deleteAllByMemberId(@Param("memberId") Long memberId);
 
-  @Query("SELECT l FROM Limjang l join fetch l.limjangPrice WHERE l.limjangId = :id AND l.memberId = :member AND l.deleted = false")
-  Optional<Limjang> findByLimjangIdAndMemberIdWithLimjangPriceAndDeletedIsFalse(@Param("id") Long id, @Param("member") Member member);
+	@Query("SELECT l FROM Limjang l join fetch l.limjangPrice WHERE l.limjangId = :id AND l.memberId = :member AND l.deleted = false")
+	Optional<Limjang> findByLimjangIdAndMemberIdWithLimjangPriceAndDeletedIsFalse(@Param("id") Long id,
+		@Param("member") Member member);
 
-  @Query("SELECT l FROM Limjang l join fetch l.limjangPrice left join fetch l.report WHERE l.limjangId = :id AND l.memberId = :member AND l.deleted = false")
-  Optional<Limjang> findByLimjangIdAndMemberAndDeletedIsFalse(@Param("id") Long id, @Param("member") Member member);
+	@Query("SELECT l FROM Limjang l join fetch l.limjangPrice left join fetch l.report WHERE l.limjangId = :id AND l.memberId = :member AND l.deleted = false")
+	Optional<Limjang> findByLimjangIdAndMemberAndDeletedIsFalse(@Param("id") Long id, @Param("member") Member member);
 
-  @Query("SELECT l FROM Limjang l WHERE l.limjangId = :id AND l.deleted = false")
-  Optional<Limjang> findByLimjangIdAndDeletedIsFalse(@Param("id") Long id);
+	@Query("SELECT l FROM Limjang l WHERE l.limjangId = :id AND l.deleted = false")
+	Optional<Limjang> findByLimjangIdAndDeletedIsFalse(@Param("id") Long id);
+
+	@Query("SELECT l FROM Limjang l join fetch l.addressEntity join fetch l.limjangPrice WHERE l.limjangId = :id AND l.deleted = false")
+	Optional<Limjang> findNoteByIdWithAddressAndNotePriceWhereDeletedIsFalse(@Param("id") Long id);
+
 }


### PR DESCRIPTION
## 작업내용

임장 수정 API 구현

## 상세설명_ & 캡쳐
- 리소스 일부 수정이라 Patch method로 설정
- 예외처리 완료
- 로컬에서 테스트 완료

[구현]

### Repository

- fetch join을 통해 임장, 임장 가격, 주소 모두 한번에 가져오도록 했습니다.
```java
	@Query("SELECT l FROM Limjang l join fetch l.addressEntity join fetch l.limjangPrice WHERE l.limjangId = :id AND l.deleted = false")
	Optional<Limjang> findByIdWithAddressAndNotePriceWhereDeletedIsFalse(@Param("id") Long id);
```

- Finder 컴포넌트에 찾는 리소스 없으면 예외 던지도록 처리했습니다.
- 메소드명은 get으로 설정 (find : 리소스 있을 수도 없을수도 있음, get : 있다는걸 보장함이라고 주워들어서 그렇게 해봤습니다)
```java
@Component
@RequiredArgsConstructor
public class NoteFinder {
...생략
	protected Limjang getNoteByIdWithAddressAndNotePriceWhereDeletedIsFalse(long id) {
		return limjangRepository.findByIdWithAddressAndNotePriceWhereDeletedIsFalse(id)
			.orElseThrow(() -> new LimjangHandler(ErrorStatus.LIMJANG_NOTFOUND_ERROR));
	}
```
- 엔티티 내부에 update 생성해 해당 메소드를 통해 update 되도록 처리했습니다.
- 더티체킹으로 변경된 부분 있을 경우 update 쿼리가 나갑니다.
```java
public void updateNote(Long noteId, NotePatchRequest request) {
		Limjang note = noteFinder.getNoteByIdWithAddressAndNotePriceWhereDeletedIsFalse(noteId);

		validatePriceType(note.getPurpose(), request.priceType());

		LimjangPrice newPrice = request.toUpdatedPrice(note.getPurpose());
		Address newAddress = request.toUpdatedAddress();

		note.getAddressEntity().update(newAddress);
		note.getLimjangPrice().updateLimjangPrice(newPrice);
		note.updateNote(request.nickname(), request.priceType(), request.floor(), request.pyong());
	}
```

- 

[예외처리]
- 아래 조건 안 맞을시 예외던지도록 처리
- 부동산 투자 목적 => "실거래가" (무조건)
- 실거주목적 => "월세", "전세", "매매" 중 1개
