### PR TITLE
[feat/#322] 임장 리스트 - 공유하기 선택 API 구현

### DIFF
--- a/src/main/java/umc/th/juinjang/api/image/service/ImageFinder.java
+++ b/src/main/java/umc/th/juinjang/api/image/service/ImageFinder.java
@@ -1,0 +1,21 @@
+package umc.th.juinjang.api.image.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.domain.image.model.Image;
+import umc.th.juinjang.domain.image.repository.ImageRepository;
+import umc.th.juinjang.domain.limjang.model.Limjang;
+
+@Component
+@RequiredArgsConstructor
+public class ImageFinder {
+
+	private final ImageRepository imageRepository;
+
+	public List<Image> findAllFirstCreatedImagePerNote(List<Limjang> notes) {
+		return imageRepository.findAllFirstCreatedImagePerNote(notes);
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/limjang/controller/NoteControllerV2.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/controller/NoteControllerV2.java
@@ -18,6 +18,7 @@ import umc.th.juinjang.api.dto.ApiResponse;
 import umc.th.juinjang.api.limjang.controller.parameter.LimjangSortOptions;
 import umc.th.juinjang.api.limjang.controller.request.NotePatchRequest;
 import umc.th.juinjang.api.limjang.controller.request.NotePostRequest;
+import umc.th.juinjang.api.limjang.service.response.UserNotesShareableGetResponse;
 import umc.th.juinjang.api.limjang.service.NoteCommandServiceV2;
 import umc.th.juinjang.api.limjang.service.NoteQueryServiceV2;
 import umc.th.juinjang.api.limjang.service.response.UserNotesGetResponse;
@@ -25,7 +26,7 @@ import umc.th.juinjang.common.code.status.SuccessStatus;
 import umc.th.juinjang.domain.member.model.Member;
 
 @RestController
-@RequestMapping("/api/v2/notes")
+@RequestMapping("/api/v2")
 @RequiredArgsConstructor
 public class NoteControllerV2 {
 
@@ -33,7 +34,7 @@ public class NoteControllerV2 {
 	private final NoteQueryServiceV2 noteQueryService;
 
 	@Operation(summary = "임장 생성 API V2")
-	@PostMapping
+	@PostMapping("/notes")
 	public ApiResponse<Void> createNote(@RequestBody @Valid NotePostRequest request,
 		@AuthenticationPrincipal Member member) {
 		noteCommandService.createNote(request, member);
@@ -41,7 +42,7 @@ public class NoteControllerV2 {
 	}
 
 	@Operation(summary = "마이 노트 조회 API V2")
-	@GetMapping
+	@GetMapping("/users/notes")
 	public ApiResponse<UserNotesGetResponse> findUsersNotes(
 		@RequestParam("sort") LimjangSortOptions sortOptions,
 		@AuthenticationPrincipal Member member) {
@@ -49,11 +50,17 @@ public class NoteControllerV2 {
 	}
 
 	@Operation(summary = "임장 수정 API V2")
-	@PatchMapping("/{noteId}")
+	@PatchMapping("/notes/{noteId}")
 	public ApiResponse<Void> updateNote(@PathVariable(name = "noteId") Long noteId,
 		@RequestBody @Valid NotePatchRequest request,
 		@AuthenticationPrincipal Member member) {
 		noteCommandService.updateNote(noteId, request);
 		return ApiResponse.onSuccess(null);
+	}
+
+	@Operation(summary = "임장 노트 출력 - 공유하기 선택 화면 API")
+	@GetMapping("/users/notes/shareable")
+	public ApiResponse<UserNotesShareableGetResponse> findNotesShareable(@AuthenticationPrincipal Member member) {
+		return ApiResponse.onSuccess(noteQueryService.findNotesShareable(member));
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/limjang/service/NoteFinder.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/service/NoteFinder.java
@@ -31,4 +31,10 @@ public class NoteFinder {
 		return limjangRepository.findByIdWithAddressAndNotePriceWhereDeletedIsFalse(id)
 			.orElseThrow(() -> new LimjangHandler(ErrorStatus.LIMJANG_NOTFOUND_ERROR));
 	}
+
+	protected List<Limjang> getAllByMemberWithAddressAndNotePriceWhereRewardPencilIsNotNullAndDeletedIsFalse(
+		Member member) {
+		return limjangRepository.findAllByMemberWithAddressAndNotePriceWhereRewardPencilIsNotNullAndDeletedIsFalse(
+			member);
+	}
 }

--- a/src/main/java/umc/th/juinjang/api/limjang/service/NoteQueryServiceV2.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/service/NoteQueryServiceV2.java
@@ -10,9 +10,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.api.image.service.ImageFinder;
 import umc.th.juinjang.api.limjang.controller.parameter.LimjangSortOptions;
+import umc.th.juinjang.api.limjang.service.response.UserNotesShareableGetResponse;
 import umc.th.juinjang.api.limjang.service.response.UserNotesGetResponse;
 import umc.th.juinjang.api.scrap.service.ScarpFinder;
+import umc.th.juinjang.domain.image.model.Image;
 import umc.th.juinjang.domain.limjang.model.Limjang;
 import umc.th.juinjang.domain.member.model.Member;
 
@@ -22,6 +25,7 @@ public class NoteQueryServiceV2 {
 
 	private final NoteFinder noteFinder;
 	private final ScarpFinder scarpFinder;
+	private final ImageFinder imageFinder;
 
 	@Transactional(readOnly = true)
 	public UserNotesGetResponse findUsersNotes(Member member, LimjangSortOptions sortOptions) {
@@ -42,5 +46,23 @@ public class NoteQueryServiceV2 {
 			.stream()
 			.map(it -> it.getLimjangId().getLimjangId())
 			.toList());
+	}
+
+	@Transactional(readOnly = true)
+	public UserNotesShareableGetResponse findNotesShareable(Member member) {
+		List<Limjang> notes = noteFinder.getAllByMemberWithAddressAndNotePriceWhereRewardPencilIsNotNullAndDeletedIsFalse(
+			member);
+
+		List<Image> imageList = imageFinder.findAllFirstCreatedImagePerNote(notes);
+
+		return UserNotesShareableGetResponse.of(notes, mapToNoteIdAndImageId(imageList), mapToNoteScrapStatus(notes));
+	}
+
+	private Map<Long, String> mapToNoteIdAndImageId(List<Image> imageList) {
+		return imageList.stream()
+			.collect(Collectors.toMap(
+				image -> image.getLimjangId().getLimjangId(),
+				image -> image.getImageUrl()
+			));
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/limjang/service/response/UserNotesShareableGetResponse.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/service/response/UserNotesShareableGetResponse.java
@@ -1,0 +1,58 @@
+package umc.th.juinjang.api.limjang.service.response;
+
+import java.util.List;
+import java.util.Map;
+
+import umc.th.juinjang.domain.limjang.model.Limjang;
+import umc.th.juinjang.domain.limjang.model.LimjangPriceType;
+import umc.th.juinjang.domain.limjang.model.LimjangPropertyType;
+import umc.th.juinjang.domain.limjang.model.LimjangPurpose;
+
+public record UserNotesShareableGetResponse(
+	List<UserNoteShareableResponse> notes
+) {
+	record UserNoteShareableResponse(
+		long noteId,
+		LimjangPurpose purposeType,
+		LimjangPropertyType propertyType,
+		LimjangPriceType priceType,
+		String name,
+		String imageUrl,
+		boolean isScraped,
+		String rate,
+		String price,
+		String monthlyRent,
+		Integer pyong,
+		String floor,
+		String shortAddress,
+		int rewardPencil
+	) {
+
+		static UserNoteShareableResponse of(Limjang limjang, String imageUrl, boolean isScraped) {
+			return new UserNoteShareableResponse(
+				limjang.getLimjangId(), limjang.getPurpose(), limjang.getPropertyType(), limjang.getPriceType(),
+				limjang.getNickname(),
+				imageUrl,
+				isScraped,
+				limjang.getReport() == null ? null : limjang.getReport().getTotalRate().toString(),
+				limjang.getLimjangPrice().getPrice(limjang.getPriceType(), limjang.getPurpose()),
+				limjang.getPriceType() == LimjangPriceType.MONTHLY_RENT ? limjang.getLimjangPrice().getMonthlyRent() :
+					null,
+				limjang.getPyong(),
+				limjang.getFloor(),
+				limjang.getAddressEntity().getShortAddress(),
+				limjang.getRewardPencil()
+			);
+		}
+	}
+
+	public static UserNotesShareableGetResponse of(List<Limjang> limjangs, Map<Long, String> imageUrl,
+		Map<Long, Boolean> isScraped) {
+		return new UserNotesShareableGetResponse(
+			limjangs.stream()
+				.map(it -> UserNoteShareableResponse.of(it, imageUrl.get(it.getLimjangId()),
+					isScraped.get(it.getLimjangId())))
+				.toList());
+	}
+}
+

--- a/src/main/java/umc/th/juinjang/domain/image/repository/ImageQueryDslRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/image/repository/ImageQueryDslRepository.java
@@ -1,0 +1,11 @@
+package umc.th.juinjang.domain.image.repository;
+
+import java.util.List;
+
+import umc.th.juinjang.domain.image.model.Image;
+import umc.th.juinjang.domain.limjang.model.Limjang;
+
+public interface ImageQueryDslRepository {
+
+	List<Image> findAllFirstCreatedImagePerNote(List<Limjang> limjangs);
+}

--- a/src/main/java/umc/th/juinjang/domain/image/repository/ImageQueryDslRepositoryImpl.java
+++ b/src/main/java/umc/th/juinjang/domain/image/repository/ImageQueryDslRepositoryImpl.java
@@ -1,0 +1,40 @@
+package umc.th.juinjang.domain.image.repository;
+
+import static umc.th.juinjang.domain.image.model.QImage.*;
+
+import java.util.List;
+
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.JPQLTemplates;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import umc.th.juinjang.domain.image.model.Image;
+import umc.th.juinjang.domain.limjang.model.Limjang;
+
+public class ImageQueryDslRepositoryImpl implements ImageQueryDslRepository {
+	private final JPAQueryFactory queryFactory;
+
+	public ImageQueryDslRepositoryImpl(EntityManager em) {
+		this.queryFactory = new JPAQueryFactory(JPQLTemplates.DEFAULT, em);
+	}
+
+	@Override
+	public List<Image> findAllFirstCreatedImagePerNote(List<Limjang> limjangs) {
+		return queryFactory
+			.selectFrom(image)
+			.where(image.imageId.in(
+				subqueryFirstCreatedImagePerNote(limjangs)
+			))
+			.fetch();
+	}
+
+	private JPQLQuery<Long> subqueryFirstCreatedImagePerNote(List<Limjang> limjangs) {
+		return JPAExpressions
+			.select(image.imageId.min())
+			.from(image)
+			.where(image.limjangId.in(limjangs))
+			.groupBy(image.limjangId);
+	}
+}

--- a/src/main/java/umc/th/juinjang/domain/image/repository/ImageRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/image/repository/ImageRepository.java
@@ -1,21 +1,23 @@
 package umc.th.juinjang.domain.image.repository;
 
 import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
+
 import umc.th.juinjang.domain.image.model.Image;
 import umc.th.juinjang.domain.limjang.model.Limjang;
 
-public interface ImageRepository extends JpaRepository<Image, Long> {
+public interface ImageRepository extends JpaRepository<Image, Long>, ImageQueryDslRepository {
 
-  List<Image> findImagesByLimjangId(Limjang limjang);
+	List<Image> findImagesByLimjangId(Limjang limjang);
 
-  @Transactional
-  @Modifying
-  @Query(value = "DELETE FROM image i WHERE i.limjang_id = :limjangId", nativeQuery = true)
-  void deleteByLimjangId(@Param("limjangId") Long limjangId);
+	@Transactional
+	@Modifying
+	@Query(value = "DELETE FROM image i WHERE i.limjang_id = :limjangId", nativeQuery = true)
+	void deleteByLimjangId(@Param("limjangId") Long limjangId);
 
 }

--- a/src/main/java/umc/th/juinjang/domain/limjang/repository/LimjangRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/limjang/repository/LimjangRepository.java
@@ -60,4 +60,7 @@ public interface LimjangRepository extends JpaRepository<Limjang, Long>, Limjang
 	@Query("SELECT l FROM Limjang l join fetch l.addressEntity join fetch l.limjangPrice WHERE l.limjangId = :id AND l.deleted = false")
 	Optional<Limjang> findByIdWithAddressAndNotePriceWhereDeletedIsFalse(@Param("id") Long id);
 
+	@Query("SELECT l FROM Limjang l join fetch l.addressEntity join fetch l.limjangPrice left join fetch l.report WHERE l.memberId = :member AND l.deleted = false AND l.rewardPencil IS NOT null ")
+	List<Limjang> findAllByMemberWithAddressAndNotePriceWhereRewardPencilIsNotNullAndDeletedIsFalse(
+		@Param("member") Member member);
 }


### PR DESCRIPTION
## 작업내용

임장 리스트 - 공유하기 선택 API 구현
<img width="291" alt="임장리스트" src="https://github.com/user-attachments/assets/ade0aa23-55e5-4b01-bca9-5fe3cf32cef0" />

## 상세설명_ & 캡쳐

**로컬에서 테스트 완료**

**임장 리포지토리에서 가져올 때 rewardPencil이 null이 아닌 것들을 가져오도록 구현했습니다.**
- addressEntity, limjangPrice, report(left join) 과 fetch join
```java
	@Query("SELECT l FROM Limjang l join fetch l.addressEntity join fetch l.limjangPrice left join fetch l.report WHERE l.memberId = :member AND l.deleted = false AND l.rewardPencil IS NOT null ")
	List<Limjang> findAllByMemberWithAddressAndNotePriceWhereRewardPencilIsNotNullAndDeletedIsFalse(
		@Param("member") Member member);
```

**리스트 중 이미지 1개만 가져오게 하는 부분을 QueryDSL을 통해서 구현했습니다.**
- 가장 먼저 생성된 이미지를 출력해야함
```java
	@Override
	public List<Image> findAllFirstCreatedImagePerNote(List<Limjang> limjangs) {
		return queryFactory
			.selectFrom(image)
			.where(image.imageId.in(
				subqueryFirstCreatedImagePerNote(limjangs)
			))
			.fetch();
	}

	private JPQLQuery<Long> subqueryFirstCreatedImagePerNote(List<Limjang> limjangs) {
		return JPAExpressions
			.select(image.imageId.min())
			.from(image)
			.where(image.limjangId.in(limjangs))
			.groupBy(image.limjangId);
	}
```

결과
```json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": {
    "notes": [
      {
        "noteId": 1,
        "purposeType": "RESIDENTIAL_PURPOSE",
        "propertyType": "APARTMENT",
        "priceType": "MARKET_PRICE",
        "name": "내집",
        "imageUrl": "https://juinjangbucket.s3.ap-northeast-2.amazonaws.com/image/2536fc00-eef1-4c99-baa3-3103c49d08d8free-icon-github-logo-25231.png",
        "isScraped": false,
        "rate": null,
        "price": "2200000000",
        "monthlyRent": null,
        "pyong": 10,
        "floor": "10",
        "shortAddress": "강남구 신사동",
        "rewardPencil": 3
      },
      {
        "noteId": 2,
        "purposeType": "INVESTMENT",
        "propertyType": "APARTMENT",
        "priceType": "SALE",
        "name": "내집",
        "imageUrl": null,
        "isScraped": false,
        "rate": null,
        "price": "100000",
        "monthlyRent": null,
        "pyong": 10,
        "floor": "5",
        "shortAddress": "구리시 인창동",
        "rewardPencil": 3
      }
    ]
  }
}
```
