### PR TITLE
[feat/#341] 공유 임장 구매 관련 API 구현

### DIFF
--- a/src/main/java/umc/th/juinjang/api/pencil/service/AcquiredPencilUpdater.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/service/AcquiredPencilUpdater.java
@@ -1,0 +1,19 @@
+package umc.th.juinjang.api.pencil.service;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.domain.pencil.acquired.model.AcquiredPencil;
+import umc.th.juinjang.domain.pencil.acquired.repository.AcquiredPencilRepository;
+
+@Component
+@RequiredArgsConstructor
+public class AcquiredPencilUpdater {
+
+	private final AcquiredPencilRepository acquiredPencilRepository;
+
+	public void save(AcquiredPencil acquiredPencil) {
+		acquiredPencilRepository.save(acquiredPencil);
+	}
+
+}

--- a/src/main/java/umc/th/juinjang/api/pencil/service/UsedPencilFinder.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/service/UsedPencilFinder.java
@@ -1,0 +1,19 @@
+package umc.th.juinjang.api.pencil.service;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.domain.member.model.Member;
+import umc.th.juinjang.domain.pencil.used.repository.UsedPencilRepository;
+
+@Component
+@RequiredArgsConstructor
+public class UsedPencilFinder {
+
+	private final UsedPencilRepository usedPencilRepository;
+
+	public boolean existsByMemberAndSharedNoteId(Member member, long sharedNoteId) {
+		return usedPencilRepository.existsByMemberAndSharedNoteId(member, sharedNoteId);
+	}
+
+}

--- a/src/main/java/umc/th/juinjang/api/pencil/service/UsedPencilUpdater.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/service/UsedPencilUpdater.java
@@ -1,0 +1,18 @@
+package umc.th.juinjang.api.pencil.service;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.domain.pencil.used.model.UsedPencil;
+import umc.th.juinjang.domain.pencil.used.repository.UsedPencilRepository;
+
+@Component
+@RequiredArgsConstructor
+public class UsedPencilUpdater {
+
+	private final UsedPencilRepository usedPencilRepository;
+
+	public void save(UsedPencil usedPencil) {
+		usedPencilRepository.save(usedPencil);
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/pencilAccount/service/PencilAccountFinder.java
+++ b/src/main/java/umc/th/juinjang/api/pencilAccount/service/PencilAccountFinder.java
@@ -2,8 +2,11 @@ package umc.th.juinjang.api.pencilAccount.service;
 
 import static umc.th.juinjang.common.code.status.ErrorStatus.*;
 
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Component;
 
+import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import umc.th.juinjang.common.exception.handler.PencilAccountHandler;
@@ -26,4 +29,10 @@ public class PencilAccountFinder {
 			}
 		);
 	}
+
+	public PencilAccount findByMemberWithLock(Member member) {
+		return pencilAccountRepository.findByMemberWithLock(member)
+			.orElseThrow(() -> new PencilAccountHandler(PENCIL_ACCOUNT_NOT_FOUND));
+	}
+
 }

--- a/src/main/java/umc/th/juinjang/api/sharednote/controller/SharedNoteController.java
+++ b/src/main/java/umc/th/juinjang/api/sharednote/controller/SharedNoteController.java
@@ -1,0 +1,34 @@
+package umc.th.juinjang.api.sharednote.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.api.dto.ApiResponse;
+import umc.th.juinjang.api.limjang.controller.request.LimjangPostRequest;
+import umc.th.juinjang.api.limjang.service.response.LimjangPostResponse;
+import umc.th.juinjang.api.sharednote.service.SharedNoteCommandService;
+import umc.th.juinjang.domain.member.model.Member;
+
+@RestController
+@RequestMapping("/api/v2/shared-notes")
+@RequiredArgsConstructor
+public class SharedNoteController {
+
+	private final SharedNoteCommandService sharedNoteCommandService;
+
+	@Operation(summary = "노트 구매 API")
+	@PostMapping("/{sharedNoteId}/purchase")
+	public ApiResponse<Void> createSharedNotePurchase(@AuthenticationPrincipal Member member,
+		@PathVariable("sharedNoteId") Long sharedNoteId) {
+		sharedNoteCommandService.createSharedNotePurchase(member, sharedNoteId);
+		return ApiResponse.onSuccess(null);
+	}
+
+}

--- a/src/main/java/umc/th/juinjang/api/sharednote/service/SharedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/sharednote/service/SharedNoteCommandService.java
@@ -1,16 +1,25 @@
 package umc.th.juinjang.api.sharednote.service;
 
-import org.springframework.dao.DataIntegrityViolationException;
+import org.hibernate.exception.LockAcquisitionException;
+import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import jakarta.persistence.PessimisticLockException;
 import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.api.pencil.service.AcquiredPencilUpdater;
+import umc.th.juinjang.api.pencil.service.UsedPencilFinder;
 import umc.th.juinjang.api.pencil.service.UsedPencilUpdater;
+import umc.th.juinjang.api.pencilAccount.service.PencilAccountFinder;
 import umc.th.juinjang.common.code.status.ErrorStatus;
 import umc.th.juinjang.common.exception.handler.SharedNoteHandler;
 import umc.th.juinjang.domain.member.model.Member;
 import umc.th.juinjang.domain.note.shared.model.SharedNote;
+import umc.th.juinjang.domain.pencil.acquired.model.AcquiredPencil;
+import umc.th.juinjang.domain.pencil.acquired.model.AcquiredType;
 import umc.th.juinjang.domain.pencil.used.model.UsedPencil;
 import umc.th.juinjang.domain.pencil.used.model.Usedtype;
+import umc.th.juinjang.domain.pencilaccount.model.PencilAccount;
 
 @Service
 @RequiredArgsConstructor
@@ -18,27 +27,59 @@ public class SharedNoteCommandService {
 
 	private final SharedNoteFinder sharedNoteFinder;
 	private final UsedPencilUpdater usedPencilUpdater;
+	private final UsedPencilFinder usedPencilFinder;
+	private final AcquiredPencilUpdater acquiredPencilUpdater;
+	private final PencilAccountFinder pencilAccountFinder;
 
-	public void createSharedNotePurchase(Member member, Long sharedNoteId) {
+	@Transactional
+	public void createSharedNotePurchase(Member buyer, Long sharedNoteId) {
+		checkAlreadyPurchase(buyer, sharedNoteId);
+
 		SharedNote sharedNote = sharedNoteFinder.findById(sharedNoteId);
-		checkOwnedPencil(sharedNote);
+		Member seller = sharedNote.getMember();
+		Long price = sharedNote.getPrice();
+
 		try {
-			usedPencilUpdater.save(createUsedPencil(member, sharedNoteId, sharedNote));
-		} catch (DataIntegrityViolationException e) {
-			// 중복 결제를 방지하기 위해 member 아이디 + sharedNoteId 유니크 제약 조건 걸어도 될듯?
+			PencilAccount buyerAccount = pencilAccountFinder.findByMemberWithLock(buyer);
+			PencilAccount sellerAccount = pencilAccountFinder.findByMemberWithLock(seller);
+
+			executePayment(buyerAccount, sellerAccount, price);
+
+			usedPencilUpdater.save(createUsedPencil(buyer, sharedNoteId, sharedNote, buyerAccount));
+			acquiredPencilUpdater.save(createAcquiredPencil(sharedNoteId, seller, price));
+		} catch (CannotAcquireLockException | PessimisticLockException | LockAcquisitionException e) {
+			throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_DEADLOCK);
+		}
+	}
+
+	private void checkAlreadyPurchase(Member buyer, Long sharedNoteId) {
+		if (usedPencilFinder.existsByMemberAndSharedNoteId(buyer, sharedNoteId)) {
 			throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_CONFLICT);
 		}
 	}
 
-	private void checkOwnedPencil(SharedNote sharedNote) {
-		int usersPencil = 1;
-		if (usersPencil - sharedNote.getPrice() < 0) {
-			throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_ALREADY_PURCHASE);
+	public void executePayment(PencilAccount buyerAccount, PencilAccount sellerAccount, Long price) {
+		long acquiredUsed = Math.min(buyerAccount.getAcquiredBalance(), price);
+		buyerAccount.decreaseAcquiredBalance(acquiredUsed);
+
+		long unpaidPencil = price - acquiredUsed;
+		if (unpaidPencil > 0) {
+			if (buyerAccount.getPurchasedBalance() < unpaidPencil) {
+				throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_NOT_ENOUGH_PENCIL);
+			}
+			buyerAccount.updatePurchasedBalance(unpaidPencil);
 		}
+
+		sellerAccount.increaseAcquiredBalance(price);
 	}
 
-	private UsedPencil createUsedPencil(Member member, Long sharedNoteId, SharedNote sharedNote) {
+	private AcquiredPencil createAcquiredPencil(Long sharedNoteId, Member seller, Long price) {
+		return AcquiredPencil.create(seller, "", sharedNoteId, price, false, AcquiredType.SOLD);
+	}
+
+	private UsedPencil createUsedPencil(Member member, Long sharedNoteId, SharedNote sharedNote,
+		PencilAccount buyerAccount) {
 		return UsedPencil.create(member, sharedNoteId, sharedNote.getPrice(), Usedtype.OWNED,
-			sharedNote.getBuildingName(), 0L);
+			sharedNote.getBuildingName(), buyerAccount.getTotalBalance());
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/sharednote/service/SharedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/sharednote/service/SharedNoteCommandService.java
@@ -1,0 +1,44 @@
+package umc.th.juinjang.api.sharednote.service;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.api.pencil.service.UsedPencilUpdater;
+import umc.th.juinjang.common.code.status.ErrorStatus;
+import umc.th.juinjang.common.exception.handler.SharedNoteHandler;
+import umc.th.juinjang.domain.member.model.Member;
+import umc.th.juinjang.domain.note.shared.model.SharedNote;
+import umc.th.juinjang.domain.pencil.used.model.UsedPencil;
+import umc.th.juinjang.domain.pencil.used.model.Usedtype;
+
+@Service
+@RequiredArgsConstructor
+public class SharedNoteCommandService {
+
+	private final SharedNoteFinder sharedNoteFinder;
+	private final UsedPencilUpdater usedPencilUpdater;
+
+	public void createSharedNotePurchase(Member member, Long sharedNoteId) {
+		SharedNote sharedNote = sharedNoteFinder.findById(sharedNoteId);
+		checkOwnedPencil(sharedNote);
+		try {
+			usedPencilUpdater.save(createUsedPencil(member, sharedNoteId, sharedNote));
+		} catch (DataIntegrityViolationException e) {
+			// 중복 결제를 방지하기 위해 member 아이디 + sharedNoteId 유니크 제약 조건 걸어도 될듯?
+			throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_CONFLICT);
+		}
+	}
+
+	private void checkOwnedPencil(SharedNote sharedNote) {
+		int usersPencil = 1;
+		if (usersPencil - sharedNote.getPrice() < 0) {
+			throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_ALREADY_PURCHASE);
+		}
+	}
+
+	private UsedPencil createUsedPencil(Member member, Long sharedNoteId, SharedNote sharedNote) {
+		return UsedPencil.create(member, sharedNoteId, sharedNote.getPrice(), Usedtype.OWNED,
+			sharedNote.getBuildingName(), 0L);
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/sharednote/service/SharedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/sharednote/service/SharedNoteCommandService.java
@@ -67,7 +67,7 @@ public class SharedNoteCommandService {
 			if (buyerAccount.getPurchasedBalance() < unpaidPencil) {
 				throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_NOT_ENOUGH_PENCIL);
 			}
-			buyerAccount.updatePurchasedBalance(unpaidPencil);
+			buyerAccount.decreasePurchasedBalance(unpaidPencil);
 		}
 
 		sellerAccount.increaseAcquiredBalance(price);

--- a/src/main/java/umc/th/juinjang/api/sharednote/service/SharedNoteFinder.java
+++ b/src/main/java/umc/th/juinjang/api/sharednote/service/SharedNoteFinder.java
@@ -15,6 +15,7 @@ public class SharedNoteFinder {
 	private final SharedNoteRepository sharedNoteRepository;
 
 	SharedNote findById(Long id) {
-		sharedNoteRepository.findById(id).orElseThrow(new SharedNoteHandler(ErrorStatus.));
+		return sharedNoteRepository.findById(id)
+			.orElseThrow(() -> new SharedNoteHandler(ErrorStatus.SHAREDNOTE_NOT_FOUND));
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/sharednote/service/SharedNoteFinder.java
+++ b/src/main/java/umc/th/juinjang/api/sharednote/service/SharedNoteFinder.java
@@ -1,0 +1,20 @@
+package umc.th.juinjang.api.sharednote.service;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.common.code.status.ErrorStatus;
+import umc.th.juinjang.common.exception.handler.SharedNoteHandler;
+import umc.th.juinjang.domain.note.shared.model.SharedNote;
+import umc.th.juinjang.domain.note.shared.repository.SharedNoteRepository;
+
+@Component
+@RequiredArgsConstructor
+public class SharedNoteFinder {
+
+	private final SharedNoteRepository sharedNoteRepository;
+
+	SharedNote findById(Long id) {
+		sharedNoteRepository.findById(id).orElseThrow(new SharedNoteHandler(ErrorStatus.));
+	}
+}

--- a/src/main/java/umc/th/juinjang/common/code/status/ErrorStatus.java
+++ b/src/main/java/umc/th/juinjang/common/code/status/ErrorStatus.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import umc.th.juinjang.api.sharednote.service.SharedNoteFinder;
 import umc.th.juinjang.common.code.BaseErrorCode;
 import umc.th.juinjang.common.code.ErrorReasonDTO;
 
@@ -102,7 +103,11 @@ public enum ErrorStatus implements BaseErrorCode {
 	DISCORD_ALERT_ERROR(HttpStatus.NOT_FOUND, "DISCORD400", "discord 알림 수신 중 오류가 발생했습니다."),
 
 	// PencilAccount alert
-	PENCIL_ACCOUNT_NOT_FOUND(HttpStatus.BAD_REQUEST, "ACCOUNT4000", "멤버에 해당하는 계좌가 존재하지 않습니다.");
+	PENCIL_ACCOUNT_NOT_FOUND(HttpStatus.BAD_REQUEST, "ACCOUNT4000", "멤버에 해당하는 계좌가 존재하지 않습니다."),
+
+	SHAREDNOTE_NOT_FOUND(HttpStatus.BAD_REQUEST, "SHAREDNOTE4000", "해당하는 공유노트가 존재하지 않습니다."),
+	SHAREDNOTE_ALREADY_PURCHASE(HttpStatus.BAD_REQUEST, "SHAREDNOTE4001", "보유한 연필 수가 부족합니다."),
+	SHAREDNOTE_CONFLICT(HttpStatus.CONFLICT, "SHAREDNOTE4002", "이미 구매한 노트입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/umc/th/juinjang/common/code/status/ErrorStatus.java
+++ b/src/main/java/umc/th/juinjang/common/code/status/ErrorStatus.java
@@ -106,8 +106,9 @@ public enum ErrorStatus implements BaseErrorCode {
 	PENCIL_ACCOUNT_NOT_FOUND(HttpStatus.BAD_REQUEST, "ACCOUNT4000", "멤버에 해당하는 계좌가 존재하지 않습니다."),
 
 	SHAREDNOTE_NOT_FOUND(HttpStatus.BAD_REQUEST, "SHAREDNOTE4000", "해당하는 공유노트가 존재하지 않습니다."),
-	SHAREDNOTE_ALREADY_PURCHASE(HttpStatus.BAD_REQUEST, "SHAREDNOTE4001", "보유한 연필 수가 부족합니다."),
-	SHAREDNOTE_CONFLICT(HttpStatus.CONFLICT, "SHAREDNOTE4002", "이미 구매한 노트입니다.");
+	SHAREDNOTE_NOT_ENOUGH_PENCIL(HttpStatus.BAD_REQUEST, "SHAREDNOTE4001", "보유한 연필 수가 부족합니다."),
+	SHAREDNOTE_CONFLICT(HttpStatus.CONFLICT, "SHAREDNOTE4002", "이미 구매한 노트입니다."),
+	SHAREDNOTE_DEADLOCK(HttpStatus.LOCKED, "SHAREDNOTE4003", "잠시 후 다시 시도해주세요. 현재 다른 요청이 처리 중입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/umc/th/juinjang/common/exception/ExceptionAdvice.java
+++ b/src/main/java/umc/th/juinjang/common/exception/ExceptionAdvice.java
@@ -27,7 +27,7 @@ import umc.th.juinjang.common.code.status.ErrorStatus;
 @RestControllerAdvice(annotations = {RestController.class})
 public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
-	@org.springframework.web.bind.annotation.ExceptionHandler
+	@ExceptionHandler
 	public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
 		String errorMessage = e.getConstraintViolations().stream()
 			.map(constraintViolation -> constraintViolation.getMessage())
@@ -37,7 +37,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 		return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY, request);
 	}
 
-	@org.springframework.web.bind.annotation.ExceptionHandler
+	@ExceptionHandler
 	public ResponseEntity<Object> exception(Exception e, WebRequest request) {
 		e.printStackTrace();
 

--- a/src/main/java/umc/th/juinjang/common/exception/handler/SharedNoteHandler.java
+++ b/src/main/java/umc/th/juinjang/common/exception/handler/SharedNoteHandler.java
@@ -1,0 +1,10 @@
+package umc.th.juinjang.common.exception.handler;
+
+import umc.th.juinjang.common.code.BaseErrorCode;
+import umc.th.juinjang.common.exception.GeneralException;
+
+public class SharedNoteHandler extends GeneralException {
+	public SharedNoteHandler(BaseErrorCode code) {
+		super(code);
+	}
+}

--- a/src/main/java/umc/th/juinjang/domain/note/shared/model/SharedNote.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/model/SharedNote.java
@@ -1,5 +1,6 @@
 package umc.th.juinjang.domain.note.shared.model;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.FetchType;
 
 import java.sql.Timestamp;
@@ -38,9 +39,11 @@ public class SharedNote extends BaseEntity {
 	private boolean isImageShared;
 
 	@Comment("임장시기 연도")
+	@Column(name = "note_year")
 	private int year;
 
 	@Comment("임장시기 월")
+	@Column(name = "note_month")
 	private int month;
 
 	// TODO : 임장시기 - 시기 추후에, ENUM 으로 변경 필요
@@ -49,7 +52,7 @@ public class SharedNote extends BaseEntity {
 	private String review;
 
 	@Comment("임장 가격")
-	private int price;
+	private Long price;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "limjang_id", nullable = false, unique = true)

--- a/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteRepository.java
@@ -1,0 +1,8 @@
+package umc.th.juinjang.domain.note.shared.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import umc.th.juinjang.domain.note.shared.model.SharedNote;
+
+public interface SharedNoteRepository extends JpaRepository<SharedNote, Long> {
+}

--- a/src/main/java/umc/th/juinjang/domain/pencil/acquired/model/AcquiredPencil.java
+++ b/src/main/java/umc/th/juinjang/domain/pencil/acquired/model/AcquiredPencil.java
@@ -1,12 +1,15 @@
 package umc.th.juinjang.domain.pencil.acquired.model;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import umc.th.juinjang.domain.member.model.Member;
@@ -26,11 +29,36 @@ public class AcquiredPencil {
 
 	private String content;
 
-	private String sharedNoteId;
+	private Long sharedNoteId;
 
-	private int acquiredQuantity;
+	private Long acquiredQuantity;
 
 	private boolean isRead;
 
-	private String type; // Note, Add, Sold
+	@Enumerated(EnumType.STRING)
+	private AcquiredType type; // Note, Add, Sold
+
+	@Builder
+	private AcquiredPencil(Member member, String content, Long sharedNoteId, Long acquiredQuantity, boolean isRead,
+		AcquiredType type) {
+		this.member = member;
+		this.content = content;
+		this.sharedNoteId = sharedNoteId;
+		this.acquiredQuantity = acquiredQuantity;
+		this.isRead = isRead;
+		this.type = type;
+	}
+
+	public static AcquiredPencil create(Member member, String content, Long sharedNoteId, Long acquiredQuantity,
+		boolean isRead,
+		AcquiredType type) {
+		return AcquiredPencil.builder()
+			.member(member)
+			.content(content)
+			.sharedNoteId(sharedNoteId)
+			.acquiredQuantity(acquiredQuantity)
+			.isRead(isRead)
+			.type(type)
+			.build();
+	}
 }

--- a/src/main/java/umc/th/juinjang/domain/pencil/acquired/model/AcquiredType.java
+++ b/src/main/java/umc/th/juinjang/domain/pencil/acquired/model/AcquiredType.java
@@ -1,0 +1,5 @@
+package umc.th.juinjang.domain.pencil.acquired.model;
+
+public enum AcquiredType {
+	NOTE, AD, SOLD
+}

--- a/src/main/java/umc/th/juinjang/domain/pencil/acquired/repository/AcquiredPencilRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/pencil/acquired/repository/AcquiredPencilRepository.java
@@ -1,0 +1,8 @@
+package umc.th.juinjang.domain.pencil.acquired.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import umc.th.juinjang.domain.pencil.acquired.model.AcquiredPencil;
+
+public interface AcquiredPencilRepository extends JpaRepository<AcquiredPencil, Long> {
+}

--- a/src/main/java/umc/th/juinjang/domain/pencil/used/model/UsedPencil.java
+++ b/src/main/java/umc/th/juinjang/domain/pencil/used/model/UsedPencil.java
@@ -40,7 +40,7 @@ public class UsedPencil extends BaseEntity {
 	@Column(name = "shared_note_id")
 	private Long sharedNoteId;
 
-	private int usedQuantity;
+	private Long usedQuantity;
 
 	// TODO: 우선 OWNED(소장) 하나만 추가
 	@Enumerated(EnumType.STRING)
@@ -50,7 +50,7 @@ public class UsedPencil extends BaseEntity {
 
 	private Long remainQuantity;
 
-	public static UsedPencil create(Member member, Long sharedNoteId, int usedQuantity, Usedtype type,
+	public static UsedPencil create(Member member, Long sharedNoteId, Long usedQuantity, Usedtype type,
 		String buildingName, Long remainQuantity) {
 		return new UsedPencil(
 			member,
@@ -63,7 +63,7 @@ public class UsedPencil extends BaseEntity {
 	}
 
 	@Builder
-	private UsedPencil(Member member, Long sharedNoteId, int usedQuantity, Usedtype type,
+	private UsedPencil(Member member, Long sharedNoteId, Long usedQuantity, Usedtype type,
 		String buildingName, Long remainQuantity) {
 		this.member = member;
 		this.sharedNoteId = sharedNoteId;

--- a/src/main/java/umc/th/juinjang/domain/pencil/used/model/UsedPencil.java
+++ b/src/main/java/umc/th/juinjang/domain/pencil/used/model/UsedPencil.java
@@ -1,12 +1,18 @@
 package umc.th.juinjang.domain.pencil.used.model;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import umc.th.juinjang.domain.common.BaseEntity;
@@ -15,6 +21,12 @@ import umc.th.juinjang.domain.member.model.Member;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Table(
+	name = "used_pencil",
+	uniqueConstraints = {
+		@UniqueConstraint(columnNames = {"member_id", "shared_note_id"})
+	}
+)
 public class UsedPencil extends BaseEntity {
 
 	@Id
@@ -25,12 +37,40 @@ public class UsedPencil extends BaseEntity {
 	@JoinColumn(name = "member_id", nullable = false)
 	private Member member;
 
-	private Long usedQuantity;
+	@Column(name = "shared_note_id")
+	private Long sharedNoteId;
+
+	private int usedQuantity;
 
 	// TODO: 우선 OWNED(소장) 하나만 추가
-	private String type;
+	@Enumerated(EnumType.STRING)
+	private Usedtype type;
 
-	private String title;
+	private String buildingName;
 
 	private Long remainQuantity;
+
+	public static UsedPencil create(Member member, Long sharedNoteId, int usedQuantity, Usedtype type,
+		String buildingName, Long remainQuantity) {
+		return new UsedPencil(
+			member,
+			sharedNoteId,
+			usedQuantity,
+			type,
+			buildingName,
+			remainQuantity
+		);
+	}
+
+	@Builder
+	private UsedPencil(Member member, Long sharedNoteId, int usedQuantity, Usedtype type,
+		String buildingName, Long remainQuantity) {
+		this.member = member;
+		this.sharedNoteId = sharedNoteId;
+		this.usedQuantity = usedQuantity;
+		this.type = type;
+		this.buildingName = buildingName;
+		this.remainQuantity = remainQuantity;
+	}
+
 }

--- a/src/main/java/umc/th/juinjang/domain/pencil/used/model/Usedtype.java
+++ b/src/main/java/umc/th/juinjang/domain/pencil/used/model/Usedtype.java
@@ -1,0 +1,5 @@
+package umc.th.juinjang.domain.pencil.used.model;
+
+public enum Usedtype {
+	OWNED
+}

--- a/src/main/java/umc/th/juinjang/domain/pencil/used/repository/UsedPencilRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/pencil/used/repository/UsedPencilRepository.java
@@ -3,8 +3,11 @@ package umc.th.juinjang.domain.pencil.used.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import umc.th.juinjang.domain.member.model.Member;
 import umc.th.juinjang.domain.pencil.used.model.UsedPencil;
 
 @Repository
 public interface UsedPencilRepository extends JpaRepository<UsedPencil, Long> {
+
+	boolean existsByMemberAndSharedNoteId(Member member, Long sharedNoteId);
 }

--- a/src/main/java/umc/th/juinjang/domain/pencilaccount/model/PencilAccount.java
+++ b/src/main/java/umc/th/juinjang/domain/pencilaccount/model/PencilAccount.java
@@ -57,7 +57,7 @@ public class PencilAccount extends BaseEntity {
 
 	}
 
-	public void updatePurchasedBalance(long price) {
+	public void decreasePurchasedBalance(long price) {
 		this.purchasedBalance -= price;
 		this.totalBalance = this.purchasedBalance + this.acquiredBalance;
 	}

--- a/src/main/java/umc/th/juinjang/domain/pencilaccount/model/PencilAccount.java
+++ b/src/main/java/umc/th/juinjang/domain/pencilaccount/model/PencilAccount.java
@@ -56,4 +56,23 @@ public class PencilAccount extends BaseEntity {
 			.member(member).build();
 
 	}
+
+	public void updatePurchasedBalance(long price) {
+		this.purchasedBalance -= price;
+		this.totalBalance = this.purchasedBalance + this.acquiredBalance;
+	}
+
+	public void recalculateTotalBalance() {
+		this.totalBalance = this.acquiredBalance + this.purchasedBalance;
+	}
+
+	public void increaseAcquiredBalance(long price) {
+		this.acquiredBalance += price;
+		this.totalBalance = this.purchasedBalance + this.acquiredBalance;
+	}
+
+	public void decreaseAcquiredBalance(long price) {
+		this.acquiredBalance -= price;
+		this.totalBalance = this.purchasedBalance + this.acquiredBalance;
+	}
 }

--- a/src/main/java/umc/th/juinjang/domain/pencilaccount/repository/PencilAccountRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/pencilaccount/repository/PencilAccountRepository.java
@@ -3,8 +3,12 @@ package umc.th.juinjang.domain.pencilaccount.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import jakarta.persistence.LockModeType;
 import umc.th.juinjang.domain.member.model.Member;
 import umc.th.juinjang.domain.pencilaccount.model.PencilAccount;
 
@@ -12,4 +16,8 @@ import umc.th.juinjang.domain.pencilaccount.model.PencilAccount;
 public interface PencilAccountRepository extends JpaRepository<PencilAccount, Long> {
 
 	Optional<PencilAccount> findByMember(Member member);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT p FROM PencilAccount p WHERE p.member = :member")
+	Optional<PencilAccount> findByMemberWithLock(@Param("member") Member member);
 }


### PR DESCRIPTION
## 작업내용

공유 임장 구매 관련 API 구현

## 상세설명_ & 캡쳐


### 비관적 락
- 데이터 정합성을 위해 계좌 조회시 비관적 락이 걸리도록 구현했습니다.
- 추후 유저나 서버가 늘어날 경우 레디스의 분산락 등을 고려해볼 수 있을 것 같습니다.
```java
	@Lock(LockModeType.PESSIMISTIC_WRITE)
	@Query("SELECT p FROM PencilAccount p WHERE p.member = :member")
	Optional<PencilAccount> findByMemberWithLock(@Param("member") Member member);
```

### 비관적 락의 데드락 이슈
- 비관적 락은 데드락이 걸릴 위험이 있기 때문에 try catch문으로 데드락 발생시 커스텀 예외가 발생하도록 했습니다. 

### 로직 설명
- 노트 가격인 sharedNote.getPrice();는 필수값이긴한데 혹시 몰라 Long 타입으로 받았습니다. 추후 long으로 변경할 예정입니다.


<순서>
1. 이미 구매한 노트인지 검사 - usedPencil 내역을 통해 조회합니다.
2. 비관적 락을 통해 구매자, 판매자의 계좌 조회
3. 연필 계좌 이체 로직 
4. 구매자의 usedPencil(연필 이용 내역), 판매자의 acquiredPencil(얻은 연필) 내역 추가

```java
@Transactional
	public void createSharedNotePurchase(Member buyer, Long sharedNoteId) {
		checkAlreadyPurchase(buyer, sharedNoteId);

		SharedNote sharedNote = sharedNoteFinder.findById(sharedNoteId);
		Member seller = sharedNote.getMember();
		Long price = sharedNote.getPrice();

		try {
			PencilAccount buyerAccount = pencilAccountFinder.findByMemberWithLock(buyer);
			PencilAccount sellerAccount = pencilAccountFinder.findByMemberWithLock(seller);

			executePayment(buyerAccount, sellerAccount, price);

			usedPencilUpdater.save(createUsedPencil(buyer, sharedNoteId, sharedNote, buyerAccount));
			acquiredPencilUpdater.save(createAcquiredPencil(sharedNoteId, seller, price));
		} catch (CannotAcquireLockException | PessimisticLockException | LockAcquisitionException e) {
			throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_DEADLOCK);
		}
	}
```

### 연필 단위 통일
- 연필 단위가 Long, int로 분산되어 있어서 엔티티의 관련 필드들을 Long으로 변경했습니다. 

### SharedNote 예약어 이슈
- SharedNote의 year, month가 DB의 예약어라 H2에서 테이블이 생성되지 않는 이슈가 있었습니다. 
- MySQL DB에는 생성되는데,,... H2만 그런건지 잘 모르겠습니다🤔
- @Column을 통해 따로 컬럼명을 지정해주었습니다.

### 추후 반영할 점
- 연필 사용 content는 아직 기획 측에서 정해지지 않아서 공백으로 두었습니다. 