### PR TITLE
[feat/#342] 공유임장 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,94 +1,99 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.2.1'
-	id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+    id 'org.springframework.boot' version '3.2.1'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'umc.5th'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 ext {
-	springCloudVersion = "2023.0.0"
+    springCloudVersion = "2023.0.0"
 }
 
 dependencyManagement {
-	imports {
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-	}
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 jar {
-	enabled = false
+    enabled = false
 }
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-	//
-	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign' // 4.1.0
+    //
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign' // 4.1.0
 //	implementation 'org.springframework.cloud:spring-cloud-commons:4.1.1'
 
     compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 //	runtimeOnly 'mysql:mysql-connector-java'
 
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-	// h2
-	runtimeOnly 'com.h2database:h2'
+    // h2
+    runtimeOnly 'com.h2database:h2'
 
-	//security
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	testImplementation 'org.springframework.security:spring-security-test'
+    //security
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
 
-	//jwt
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    //jwt
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 
-	//S3
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    //S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
-	// querydsl
-	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
-	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    // querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
-	implementation 'commons-codec:commons-codec:1.16.0'  // Base64 인코딩을 위한 의존성
+    implementation 'commons-codec:commons-codec:1.16.0'  // Base64 인코딩을 위한 의존성
 
-	// prometheus
-	implementation 'io.micrometer:micrometer-registry-prometheus'
+    // prometheus
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 def generated = 'src/main/generated'
 tasks.withType(JavaCompile).configureEach {
-	options.getGeneratedSourceOutputDirectory().set(file(generated))
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
 }
 
 clean {
-	delete file(generated)
+    delete file(generated)
 }

--- a/src/main/java/umc/th/juinjang/JuinjangApplication.java
+++ b/src/main/java/umc/th/juinjang/JuinjangApplication.java
@@ -5,10 +5,12 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAsync
 @ImportAutoConfiguration({FeignAutoConfiguration.class})
+@EnableScheduling
 public class JuinjangApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/umc/th/juinjang/api/limjang/service/LimjangSchedulerService.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/service/LimjangSchedulerService.java
@@ -1,36 +1,38 @@
 package umc.th.juinjang.api.limjang.service;
 
-
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
 import umc.th.juinjang.domain.limjang.repository.LimjangRepository;
 
 @Component
 @RequiredArgsConstructor
 public class LimjangSchedulerService {
 
-  private final LimjangRepository limjangRepository;
+	private final LimjangRepository limjangRepository;
 
-  @Transactional
-  // @Scheduled(fixedRate = 60000) // 1분 간격으로 실행 - test용
-//  @Scheduled(fixedRate = 7 * 24 * 60 * 60 * 1000) // 일주일 간격으로 실행 <- 나중에 출시하면 이걸로
-  @Scheduled(fixedRate = 31557600000L) // 일년 간격으로 실행(임시)
-  public void cleanUpData() {
-    // 삭제 필드 true 된지 1달된거 삭제
-    LocalDateTime deletionCycle = LocalDateTime.now().minusMonths(1);
+	@Transactional
+	// @Scheduled(fixedRate = 60000) // 1분 간격으로 실행 - test용
+	//  @Scheduled(fixedRate = 7 * 24 * 60 * 60 * 1000) // 일주일 간격으로 실행 <- 나중에 출시하면 이걸로
+	// @Scheduled(fixedRate = 31557600000L) // 일년 간격으로 실행(임시)
+	public void cleanUpData() {
+		// 삭제 필드 true 된지 1달된거 삭제
+		LocalDateTime deletionCycle = LocalDateTime.now().minusMonths(1);
 
-    DateTimeFormatter dtf =  DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss");
-    System.out.println("스케줄러 테스트  " + LocalDateTime.now().format(dtf));
+		DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss");
+		System.out.println("스케줄러 테스트  " + LocalDateTime.now().format(dtf));
 
-    try {
-      limjangRepository.hardDelete(deletionCycle);
-    }catch (Exception e) {
-      System.out.println("hardDelete 중 에러발생함..");
-    }
-  }
+		try {
+			limjangRepository.hardDelete(deletionCycle);
+		} catch (Exception e) {
+			System.out.println("hardDelete 중 에러발생함..");
+		}
+	}
 
 }

--- a/src/main/java/umc/th/juinjang/api/note/liked/service/LikedNoteFinder.java
+++ b/src/main/java/umc/th/juinjang/api/note/liked/service/LikedNoteFinder.java
@@ -1,0 +1,19 @@
+package umc.th.juinjang.api.note.liked.service;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.domain.member.model.Member;
+import umc.th.juinjang.domain.note.liked.model.repository.LikedNoteRepository;
+import umc.th.juinjang.domain.note.shared.model.SharedNote;
+
+@Component
+@RequiredArgsConstructor
+public class LikedNoteFinder {
+
+	private final LikedNoteRepository likedNoteRepository;
+
+	public boolean existsByMemberAndSharedNote(Member member, SharedNote sharedNote) {
+		return likedNoteRepository.existsByMemberAndSharedNote(member, sharedNote);
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/note/shared/controller/SharedNoteController.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/controller/SharedNoteController.java
@@ -1,19 +1,18 @@
-package umc.th.juinjang.api.sharednote.controller;
+package umc.th.juinjang.api.note.shared.controller;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import umc.th.juinjang.api.dto.ApiResponse;
-import umc.th.juinjang.api.limjang.controller.request.LimjangPostRequest;
-import umc.th.juinjang.api.limjang.service.response.LimjangPostResponse;
-import umc.th.juinjang.api.sharednote.service.SharedNoteCommandService;
+import umc.th.juinjang.api.note.shared.service.SharedNoteCommandService;
+import umc.th.juinjang.api.note.shared.service.SharedNoteQueryService;
+import umc.th.juinjang.api.note.shared.service.response.SharedNoteGetResponse;
 import umc.th.juinjang.domain.member.model.Member;
 
 @RestController
@@ -22,6 +21,7 @@ import umc.th.juinjang.domain.member.model.Member;
 public class SharedNoteController {
 
 	private final SharedNoteCommandService sharedNoteCommandService;
+	private final SharedNoteQueryService sharedNoteQueryService;
 
 	@Operation(summary = "노트 구매 API")
 	@PostMapping("/{sharedNoteId}/purchase")
@@ -29,6 +29,13 @@ public class SharedNoteController {
 		@PathVariable("sharedNoteId") Long sharedNoteId) {
 		sharedNoteCommandService.createSharedNotePurchase(member, sharedNoteId);
 		return ApiResponse.onSuccess(null);
+	}
+
+	@Operation(summary = "공유 노트 상세보기 API")
+	@GetMapping("/{sharedNoteId}")
+	public ApiResponse<SharedNoteGetResponse> findSharedNote(@AuthenticationPrincipal Member member,
+		@PathVariable("sharedNoteId") Long sharedNoteId) {
+		return ApiResponse.onSuccess(sharedNoteQueryService.findSharedNote(member, sharedNoteId));
 	}
 
 }

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
@@ -35,7 +35,7 @@ public class SharedNoteCommandService {
 	public void createSharedNotePurchase(Member buyer, Long sharedNoteId) {
 		checkAlreadyPurchase(buyer, sharedNoteId);
 
-		SharedNote sharedNote = sharedNoteFinder.findById(sharedNoteId);
+		SharedNote sharedNote = sharedNoteFinder.getById(sharedNoteId);
 		Member seller = sharedNote.getMember();
 		Long price = sharedNote.getPrice();
 

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
@@ -1,4 +1,4 @@
-package umc.th.juinjang.api.sharednote.service;
+package umc.th.juinjang.api.note.shared.service;
 
 import org.hibernate.exception.LockAcquisitionException;
 import org.springframework.dao.CannotAcquireLockException;

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteFinder.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteFinder.java
@@ -1,4 +1,4 @@
-package umc.th.juinjang.api.sharednote.service;
+package umc.th.juinjang.api.note.shared.service;
 
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteFinder.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteFinder.java
@@ -1,5 +1,7 @@
 package umc.th.juinjang.api.note.shared.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -14,8 +16,17 @@ public class SharedNoteFinder {
 
 	private final SharedNoteRepository sharedNoteRepository;
 
-	SharedNote findById(Long id) {
+	SharedNote getById(Long id) {
 		return sharedNoteRepository.findById(id)
 			.orElseThrow(() -> new SharedNoteHandler(ErrorStatus.SHAREDNOTE_NOT_FOUND));
+	}
+
+	SharedNote findByIdWithNoteAndAddress(Long id) {
+		return sharedNoteRepository.findByIdWithNoteAndAddress(id)
+			.orElseThrow(() -> new SharedNoteHandler(ErrorStatus.SHAREDNOTE_NOT_FOUND));
+	}
+
+	Optional<SharedNote> findById(Long id) {
+		return sharedNoteRepository.findById(id);
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteQueryService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteQueryService.java
@@ -1,0 +1,55 @@
+package umc.th.juinjang.api.note.shared.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.api.note.liked.service.LikedNoteFinder;
+import umc.th.juinjang.api.pencil.service.UsedPencilFinder;
+import umc.th.juinjang.api.note.shared.service.response.SharedNoteGetResponse;
+import umc.th.juinjang.domain.limjang.model.Limjang;
+import umc.th.juinjang.domain.member.model.Member;
+import umc.th.juinjang.domain.note.shared.model.SharedNote;
+
+@Service
+@RequiredArgsConstructor
+public class SharedNoteQueryService {
+
+	private final UsedPencilFinder usedPencilFinder;
+	private final SharedNoteFinder sharedNoteFinder;
+	private final LikedNoteFinder likedNoteFinder;
+
+	@Transactional(readOnly = true)
+	public SharedNoteGetResponse findSharedNote(Member member, Long sharedNoteId) {
+		// 노트 있는지 확인
+		SharedNote sharedNote = sharedNoteFinder.findById(sharedNoteId);
+		Limjang limjang = sharedNote.getLimjang();
+
+		// 소유했는지 판단
+		boolean isBuyer = usedPencilFinder.existsByMemberAndSharedNoteId(member, sharedNoteId);
+		int viewCount = 0;
+
+		Integer countBuyer = makeBuyerCount(usedPencilFinder.countBySharedNoteId(sharedNoteId));
+		boolean isLiked = likedNoteFinder.existsByMemberAndSharedNote(member, sharedNote);
+
+		if (isBuyer) {
+			return SharedNoteGetResponse.ofPurchased(true, limjang, limjang.getAddressEntity(), sharedNote,
+				sharedNote.getMember(), countBuyer, isLiked, viewCount);
+		}
+		return SharedNoteGetResponse.ofNotPurchased(false, limjang, limjang.getAddressEntity(), sharedNote,
+			sharedNote.getMember(), countBuyer, isLiked, viewCount);
+	}
+
+	private Integer makeBuyerCount(int count) {
+		if (count >= 100) {
+			return 100;
+		} else if (count >= 50) {
+			return 50;
+		} else if (count >= 30) {
+			return 30;
+		} else if (count >= 10) {
+			return 10;
+		}
+		return null;
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteQueryService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteQueryService.java
@@ -1,43 +1,93 @@
 package umc.th.juinjang.api.note.shared.service;
 
+import java.time.Duration;
+
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.RedisSystemException;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import umc.th.juinjang.api.note.liked.service.LikedNoteFinder;
 import umc.th.juinjang.api.pencil.service.UsedPencilFinder;
 import umc.th.juinjang.api.note.shared.service.response.SharedNoteGetResponse;
+import umc.th.juinjang.common.redis.RedisKeyFactory;
 import umc.th.juinjang.domain.limjang.model.Limjang;
 import umc.th.juinjang.domain.member.model.Member;
 import umc.th.juinjang.domain.note.shared.model.SharedNote;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class SharedNoteQueryService {
 
 	private final UsedPencilFinder usedPencilFinder;
 	private final SharedNoteFinder sharedNoteFinder;
 	private final LikedNoteFinder likedNoteFinder;
+	private final RedisTemplate<String, String> redisTemplate;
 
 	@Transactional(readOnly = true)
 	public SharedNoteGetResponse findSharedNote(Member member, Long sharedNoteId) {
-		// 노트 있는지 확인
-		SharedNote sharedNote = sharedNoteFinder.findById(sharedNoteId);
+		SharedNote sharedNote = sharedNoteFinder.findByIdWithNoteAndAddress(sharedNoteId);
 		Limjang limjang = sharedNote.getLimjang();
 
-		// 소유했는지 판단
 		boolean isBuyer = usedPencilFinder.existsByMemberAndSharedNoteId(member, sharedNoteId);
-		int viewCount = 0;
+
+		long viewCount = sharedNote.getViewCount() + getViewCount(sharedNoteId);
+		if (!isDuplicate(member.getMemberId(), sharedNoteId)) {
+			increaseViewCount(sharedNoteId);
+			viewCount++;
+			recordViewerHistory(member.getMemberId(), sharedNoteId);
+		}
 
 		Integer countBuyer = makeBuyerCount(usedPencilFinder.countBySharedNoteId(sharedNoteId));
 		boolean isLiked = likedNoteFinder.existsByMemberAndSharedNote(member, sharedNote);
 
 		if (isBuyer) {
-			return SharedNoteGetResponse.ofPurchased(true, limjang, limjang.getAddressEntity(), sharedNote,
+			return SharedNoteGetResponse.ofPurchased(isBuyer, limjang, limjang.getAddressEntity(), sharedNote,
+				sharedNote.getMember(), countBuyer, isLiked, viewCount);
+		} else {
+			return SharedNoteGetResponse.ofNotPurchased(isBuyer, limjang, limjang.getAddressEntity(), sharedNote,
 				sharedNote.getMember(), countBuyer, isLiked, viewCount);
 		}
-		return SharedNoteGetResponse.ofNotPurchased(false, limjang, limjang.getAddressEntity(), sharedNote,
-			sharedNote.getMember(), countBuyer, isLiked, viewCount);
+	}
+
+	private void recordViewerHistory(long memberId, long sharedNoteId) {
+		try {
+			redisTemplate.opsForValue()
+				.setIfAbsent(RedisKeyFactory.viewHistoryKey(sharedNoteId, memberId), "1", Duration.ofHours(3));
+		} catch (RedisConnectionFailureException | RedisSystemException e) {
+			log.error("Redis 연결 실패 - 중복 조회 기록 불가, sharedNoteId={}, memberId={}", sharedNoteId, memberId, e);
+		}
+	}
+
+	private void increaseViewCount(long sharedNoteId) {
+		try {
+			redisTemplate.opsForValue().increment(RedisKeyFactory.viewCountKey(sharedNoteId));
+		} catch (RedisConnectionFailureException | RedisSystemException e) {
+			log.error("Redis 조회수 증가 실패, sharedNoteId={}", sharedNoteId, e);
+		}
+	}
+
+	private boolean isDuplicate(long memberId, long sharedNoteId) {
+		try {
+			return Boolean.TRUE.equals(redisTemplate.hasKey(RedisKeyFactory.viewHistoryKey(sharedNoteId, memberId)));
+		} catch (RedisConnectionFailureException | RedisSystemException e) {
+			log.error("Redis 장애로 조회 기록 확인 실패. sharedNoteId={}, memberId={}", sharedNoteId, memberId, e);
+			return false;
+		}
+	}
+
+	private Long getViewCount(long sharedNoteId) {
+		try {
+			Object value = redisTemplate.opsForValue().get(RedisKeyFactory.viewCountKey(sharedNoteId));
+			return value == null ? 0L : Long.parseLong(value.toString());
+		} catch (RedisConnectionFailureException | RedisSystemException e) {
+			log.error("Redis 장애 발생, 기본값 반환 sharedNoteID={}", sharedNoteId, e);
+			return 0L;
+		}
 	}
 
 	private Integer makeBuyerCount(int count) {

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteUpdater.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteUpdater.java
@@ -1,0 +1,17 @@
+package umc.th.juinjang.api.note.shared.service;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.domain.note.shared.repository.SharedNoteRepository;
+
+@Component
+@RequiredArgsConstructor
+public class SharedNoteUpdater {
+
+	private final SharedNoteRepository sharedNoteRepository;
+
+	void updateViewCount(long sharedNoteId, long addAmount) {
+		sharedNoteRepository.incrementViewCount(sharedNoteId, addAmount);
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/ViewCountSyncScheduler.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/ViewCountSyncScheduler.java
@@ -1,0 +1,50 @@
+package umc.th.juinjang.api.note.shared.service;
+
+import static umc.th.juinjang.common.redis.RedisKeyFactory.*;
+
+import java.util.Set;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ViewCountSyncScheduler {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final SharedNoteUpdater sharedNoteUpdater;
+
+	// @Scheduled(cron = "0 0 */6 * * *") // 6시간마다 실행
+	@Scheduled(cron = "*/30 * * * * *")
+	@Transactional
+	public void syncRedisViewCountsToRDB() {
+		Set<String> keys = redisTemplate.keys(VIEW_COUNT + "*");
+		if (keys == null || keys.isEmpty())
+			return;
+
+		log.info("Redis RDB 조회수 동기화 시작: 총 {}개", keys.size());
+
+		for (String key : keys) {
+			try {
+				long sharedNoteId = Long.parseLong(key.split(":")[2]);
+				Object value = redisTemplate.opsForValue().get(key);
+				if (value == null) {
+					log.warn("조회수 값 없음 - key={}", key);
+					continue;
+				}
+				long addAmount = Long.parseLong(value.toString());
+				sharedNoteUpdater.updateViewCount(sharedNoteId, addAmount);
+				log.info("조회수 동기화: sharedNoteId={}, Redis={}", sharedNoteId, addAmount);
+				redisTemplate.delete(key);
+			} catch (Exception e) {
+				log.error("동기화 실패: key={}, error={}", key, e.getMessage(), e);
+			}
+		}
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/ViewCountSyncScheduler.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/ViewCountSyncScheduler.java
@@ -20,8 +20,7 @@ public class ViewCountSyncScheduler {
 	private final RedisTemplate<String, Object> redisTemplate;
 	private final SharedNoteUpdater sharedNoteUpdater;
 
-	// @Scheduled(cron = "0 0 */6 * * *") // 6시간마다 실행
-	@Scheduled(cron = "*/30 * * * * *")
+	@Scheduled(cron = "0 0 */6 * * *") // 6시간마다 실행
 	@Transactional
 	public void syncRedisViewCountsToRDB() {
 		Set<String> keys = redisTemplate.keys(VIEW_COUNT + "*");

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/response/SharedNoteGetResponse.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/response/SharedNoteGetResponse.java
@@ -1,0 +1,131 @@
+package umc.th.juinjang.api.note.shared.service.response;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import umc.th.juinjang.domain.image.model.Image;
+import umc.th.juinjang.domain.limjang.model.Address;
+import umc.th.juinjang.domain.limjang.model.Limjang;
+import umc.th.juinjang.domain.limjang.model.LimjangPriceType;
+import umc.th.juinjang.domain.limjang.model.LimjangPropertyType;
+import umc.th.juinjang.domain.limjang.model.LimjangPurpose;
+import umc.th.juinjang.domain.member.model.Member;
+import umc.th.juinjang.domain.note.shared.model.SharedNote;
+
+public record SharedNoteGetResponse(
+	boolean isBuyer,
+	boolean isImageShared,
+	Long requiredPencils,
+	Integer imageCount,
+	Integer checkedCount,
+	Integer reviewLength,
+	String buildingName,
+	LimjangPurpose limjangPurpose,
+	LimjangPropertyType propertyType,
+	LimjangPriceType priceType,
+	Integer buyerCount,
+	List<String> images,
+	String address,
+	String addressShort,
+	String price,
+	String monthlyRent,
+	boolean isLiked,
+	int likedCount,
+	String period,
+	String updatedAt,
+	int viewCount,
+	String floor,
+	int pyong,
+	String ownerProfileUrl,
+	String ownerNickname,
+	String ownerProfileBio
+) {
+	public static SharedNoteGetResponse ofPurchased(
+		boolean isBuyer,
+		Limjang limjang,
+		Address address,
+		SharedNote sharedNote,
+		Member member,
+		Integer buyerCount,
+		boolean isLiked,
+		int viewCount) {
+		return new SharedNoteGetResponse(
+			isBuyer,
+			sharedNote.isImageShared(),
+			sharedNote.getPrice(),
+			limjang.getImageList().size(),
+			limjang.getAnswerList().size(),
+			sharedNote.getReview().length(),
+			sharedNote.getBuildingName(),
+			limjang.getPurpose(),
+			limjang.getPropertyType(),
+			limjang.getPriceType(),
+			buyerCount,
+			findImagesUrlBySharingStatus(sharedNote.isImageShared(), limjang, 2),
+			address.getFullAddress(),
+			address.getShortAddress(),
+			limjang.getLimjangPrice().getPrice(limjang.getPriceType(), limjang.getPurpose()),
+			limjang.getPriceType() == LimjangPriceType.MONTHLY_RENT ? limjang.getLimjangPrice().getMonthlyRent() :
+				null,
+			isLiked,
+			sharedNote.getLikeCount(),
+			sharedNote.getPeriod(),
+			null,
+			viewCount,
+			limjang.getFloor(),
+			limjang.getPyong(),
+			member.getImageUrl(),
+			member.getNickname(),
+			member.getIntroduction()
+
+		);
+	}
+
+	public static SharedNoteGetResponse ofNotPurchased(
+		boolean isBuyer,
+		Limjang limjang,
+		Address address,
+		SharedNote sharedNote,
+		Member member,
+		Integer buyerCount,
+		boolean isLiked,
+		int viewCount) {
+		return new SharedNoteGetResponse(
+			isBuyer,
+			sharedNote.isImageShared(),
+			null,
+			null,
+			null,
+			null,
+			sharedNote.getBuildingName(),
+			limjang.getPurpose(),
+			limjang.getPropertyType(),
+			limjang.getPriceType(),
+			buyerCount,
+			findImagesUrlBySharingStatus(sharedNote.isImageShared(), limjang, 3),
+			address.getFullAddress(),
+			address.getShortAddress(),
+			limjang.getLimjangPrice().getPrice(limjang.getPriceType(), limjang.getPurpose()),
+			limjang.getPriceType() == LimjangPriceType.MONTHLY_RENT ? limjang.getLimjangPrice().getMonthlyRent() :
+				null,
+			isLiked,
+			sharedNote.getLikeCount(),
+			sharedNote.getPeriod(),
+			sharedNote.getUpdatedAt().format(DateTimeFormatter.ofPattern("yy.MM.dd")),
+			viewCount,
+			limjang.getFloor(),
+			limjang.getPyong(),
+			member.getImageUrl(),
+			member.getNickname(),
+			member.getIntroduction()
+
+		);
+	}
+
+	private static List<String> findImagesUrlBySharingStatus(boolean isImageShared, Limjang limjang, int maxSize) {
+		if (isImageShared) {
+			return limjang.getImageList().stream().map(Image::getImageUrl).limit(maxSize).toList();
+		}
+		return null;
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/response/SharedNoteGetResponse.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/response/SharedNoteGetResponse.java
@@ -33,14 +33,14 @@ public record SharedNoteGetResponse(
 	int likedCount,
 	String period,
 	String updatedAt,
-	int viewCount,
+	Long viewCount,
 	String floor,
 	int pyong,
 	String ownerProfileUrl,
 	String ownerNickname,
 	String ownerProfileBio
 ) {
-	public static SharedNoteGetResponse ofPurchased(
+	public static SharedNoteGetResponse ofNotPurchased(
 		boolean isBuyer,
 		Limjang limjang,
 		Address address,
@@ -48,7 +48,7 @@ public record SharedNoteGetResponse(
 		Member member,
 		Integer buyerCount,
 		boolean isLiked,
-		int viewCount) {
+		Long viewCount) {
 		return new SharedNoteGetResponse(
 			isBuyer,
 			sharedNote.isImageShared(),
@@ -81,7 +81,7 @@ public record SharedNoteGetResponse(
 		);
 	}
 
-	public static SharedNoteGetResponse ofNotPurchased(
+	public static SharedNoteGetResponse ofPurchased(
 		boolean isBuyer,
 		Limjang limjang,
 		Address address,
@@ -89,7 +89,7 @@ public record SharedNoteGetResponse(
 		Member member,
 		Integer buyerCount,
 		boolean isLiked,
-		int viewCount) {
+		Long viewCount) {
 		return new SharedNoteGetResponse(
 			isBuyer,
 			sharedNote.isImageShared(),

--- a/src/main/java/umc/th/juinjang/api/pencil/service/UsedPencilFinder.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/service/UsedPencilFinder.java
@@ -16,4 +16,8 @@ public class UsedPencilFinder {
 		return usedPencilRepository.existsByMemberAndSharedNoteId(member, sharedNoteId);
 	}
 
+	public int countBySharedNoteId(long sharedNoteId) {
+		return usedPencilRepository.countBySharedNoteId(sharedNoteId);
+	}
+
 }

--- a/src/main/java/umc/th/juinjang/common/code/status/ErrorStatus.java
+++ b/src/main/java/umc/th/juinjang/common/code/status/ErrorStatus.java
@@ -4,7 +4,6 @@ import org.springframework.http.HttpStatus;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import umc.th.juinjang.api.sharednote.service.SharedNoteFinder;
 import umc.th.juinjang.common.code.BaseErrorCode;
 import umc.th.juinjang.common.code.ErrorReasonDTO;
 

--- a/src/main/java/umc/th/juinjang/common/redis/RedisKeyFactory.java
+++ b/src/main/java/umc/th/juinjang/common/redis/RedisKeyFactory.java
@@ -1,0 +1,15 @@
+package umc.th.juinjang.common.redis;
+
+public class RedisKeyFactory {
+
+	public static final String VIEW_COUNT = "viewcount:sharedNoteId:";
+	private static final String VIEW_HISTORY = "viewed:sharedNoteId:";
+
+	public static String viewCountKey(long sharedNoteId) {
+		return VIEW_COUNT + sharedNoteId;
+	}
+
+	public static String viewHistoryKey(long sharedNoteId, long memberId) {
+		return VIEW_HISTORY + sharedNoteId + ":member:" + memberId;
+	}
+}

--- a/src/main/java/umc/th/juinjang/config/RedisConfig.java
+++ b/src/main/java/umc/th/juinjang/config/RedisConfig.java
@@ -1,0 +1,19 @@
+package umc.th.juinjang.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(factory);
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(new StringRedisSerializer());
+		return template;
+	}
+}

--- a/src/main/java/umc/th/juinjang/domain/limjang/model/Address.java
+++ b/src/main/java/umc/th/juinjang/domain/limjang/model/Address.java
@@ -83,4 +83,8 @@ public class Address extends BaseEntity {
 		this.bname1 = newAddress.bname1;
 		this.bname2 = newAddress.bname2;
 	}
+
+	public String getFullAddress() {
+		return this.roadAddress + " " + this.getAddressDetail();
+	}
 }

--- a/src/main/java/umc/th/juinjang/domain/limjang/model/Limjang.java
+++ b/src/main/java/umc/th/juinjang/domain/limjang/model/Limjang.java
@@ -89,6 +89,7 @@ public class Limjang extends BaseEntity {
 
 	// 양방향 매핑
 	@OneToMany(mappedBy = "limjangId", cascade = CascadeType.ALL, orphanRemoval = true)
+	@BatchSize(size = 100)
 	private List<ChecklistAnswer> answerList = new ArrayList<>();
 
 	@OneToOne(mappedBy = "limjangId", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/umc/th/juinjang/domain/note/liked/model/repository/LikedNoteRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/note/liked/model/repository/LikedNoteRepository.java
@@ -1,0 +1,12 @@
+package umc.th.juinjang.domain.note.liked.model.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import umc.th.juinjang.domain.member.model.Member;
+import umc.th.juinjang.domain.note.liked.model.LikedNote;
+import umc.th.juinjang.domain.note.shared.model.SharedNote;
+
+public interface LikedNoteRepository extends JpaRepository<LikedNote, Long> {
+
+	boolean existsByMemberAndSharedNote(Member member, SharedNote sharedNote);
+}

--- a/src/main/java/umc/th/juinjang/domain/note/shared/model/SharedNote.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/model/SharedNote.java
@@ -13,7 +13,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -54,9 +53,11 @@ public class SharedNote extends BaseEntity {
 	@Comment("임장 가격")
 	private Long price;
 
+	private int likeCount;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "limjang_id", nullable = false, unique = true)
-	private Limjang limjangId;
+	private Limjang limjang;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteRepository.java
@@ -1,8 +1,20 @@
 package umc.th.juinjang.domain.note.shared.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import umc.th.juinjang.domain.note.shared.model.SharedNote;
 
 public interface SharedNoteRepository extends JpaRepository<SharedNote, Long> {
+
+	@Query("select s from SharedNote s join fetch s.limjang l join fetch l.addressEntity join fetch l.limjangPrice where s.sharedNoteId = :sharedNoteId")
+	Optional<SharedNote> findByIdWithNoteAndAddress(@Param("sharedNoteId") Long sharedNoteId);
+
+	@Modifying
+	@Query("UPDATE SharedNote s SET s.viewCount = COALESCE(s.viewCount, 0) + :addAmount WHERE s.sharedNoteId = :sharedNoteId")
+	void incrementViewCount(@Param("sharedNoteId") Long sharedNoteId, @Param("addAmount") Long addAmount);
 }

--- a/src/main/java/umc/th/juinjang/domain/pencil/used/repository/UsedPencilRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/pencil/used/repository/UsedPencilRepository.java
@@ -10,4 +10,6 @@ import umc.th.juinjang.domain.pencil.used.model.UsedPencil;
 public interface UsedPencilRepository extends JpaRepository<UsedPencil, Long> {
 
 	boolean existsByMemberAndSharedNoteId(Member member, Long sharedNoteId);
+
+	int countBySharedNoteId(Long sharedNoteId);
 }


### PR DESCRIPTION
## 작업내용

이런 걸 했답니다

## 상세설명_ & 캡쳐

### Redis 관련 추가 설정이 필요합니다.
- 로컬 yml에는 아래와 같이 설정해주시고 터미널에서 레디스 설치해주시면 됩니다. dev와 prod에는 제가 머지 전 Docker compose 설정파일에 추가하겠습니다. 

application-local.yml
```yaml
spring:
  data:
    redis:
      host: localhost
      port: 6379
```

### 구현 로직 - 조회수
- 구상한 로직은 아래와 같습니다. 
- 목적 : redis로 지연 업데이트하여 빈번한 update문을 줄여 성능개선

1. Redis에서 {sharedNoteId}로 key 생성, 조회수 조회 및 + 1 증가
2. 실패한다면 RDB에서 조회
3. Redis에서 {sharedNoteId + memberId} 조합으로 key 생성 후, TTL을 6시간으로 설정하여 중복 조회 방지 
4. Spring 스케줄러를 통해 Redis - RDB 간 데이터 동기화. redis의 조회수를 RDB의 조회수로 합친 후 key 제거

### 조회수 상세 설명

```java
	long viewCount = sharedNote.getViewCount() + getViewCount(sharedNoteId);
		if (!isDuplicate(member.getMemberId(), sharedNoteId)) {
			increaseViewCount(sharedNoteId);
			viewCount++;
			recordViewerHistory(member.getMemberId(), sharedNoteId);
		}
```

**상세설명**

- viewCount 변수 : 총 조회수(RDB 조회수 + Redis조회수), 유저에게 반환하는 값
아래의 함수를 통해 Redis 조회수를 가져옵니다.
```java
	private Long getViewCount(long sharedNoteId) {
		try {
			Object value = redisTemplate.opsForValue().get(RedisKeyFactory.viewCountKey(sharedNoteId));
			return value == null ? 0L : Long.parseLong(value.toString());
		} catch (RedisConnectionFailureException | RedisSystemException e) {
			log.error("Redis 장애 발생, 기본값 반환 sharedNoteID={}", sharedNoteId, e);
			return 0L;
		}
	}

```

- isDuplicate 메소드 : Redis에서 해당 공유노트에 대한 유저의 접속기록이 있는 지 확인

```java
	private boolean isDuplicate(long memberId, long sharedNoteId) {
		try {
			return Boolean.TRUE.equals(redisTemplate.hasKey(RedisKeyFactory.viewHistoryKey(sharedNoteId, memberId)));
		} catch (RedisConnectionFailureException | RedisSystemException e) {
			log.error("Redis 장애로 조회 기록 확인 실패. sharedNoteId={}, memberId={}", sharedNoteId, memberId, e);
			return false;
		}
	}
```

- increaseViewCount : 기록에 없다면 Redis에서 해당 공유노트의 조회수 증가

```java
	private void increaseViewCount(long sharedNoteId) {
		try {
			redisTemplate.opsForValue().increment(RedisKeyFactory.viewCountKey(sharedNoteId));
		} catch (RedisConnectionFailureException | RedisSystemException e) {
			log.error("Redis 조회수 증가 실패, sharedNoteId={}", sharedNoteId, e);
		}
	}
```

- recordViewerHistory : 접속 기록을 Redis에 갱신
```java

	private void recordViewerHistory(long memberId, long sharedNoteId) {
		try {
			redisTemplate.opsForValue()
				.setIfAbsent(RedisKeyFactory.viewHistoryKey(sharedNoteId, memberId), "1", Duration.ofHours(3));
		} catch (RedisConnectionFailureException | RedisSystemException e) {
			log.error("Redis 연결 실패 - 중복 조회 기록 불가, sharedNoteId={}, memberId={}", sharedNoteId, memberId, e);
		}
	}
```




### Redis
common 패키지 아래에 아래와 같이 레디스 키를 관리하는 클래스를 생성했습니다. 
VIEW_COUNT는 조회수 카운트 관련, VIEW_HISTORY는 유저의 접속 기록 관리입니다. 

```java
public class RedisKeyFactory {

	public static final String VIEW_COUNT = "viewcount:sharedNoteId:";
	private static final String VIEW_HISTORY = "viewed:sharedNoteId:";

	public static String viewCountKey(long sharedNoteId) {
		return VIEW_COUNT + sharedNoteId;
	}

	public static String viewHistoryKey(long sharedNoteId, long memberId) {
		return VIEW_HISTORY + sharedNoteId + ":member:" + memberId;
	}
}
```
### RDB - Redis 동기화(스프링 스케줄러)
ViewCountSyncScheduler

- 동기화하는 방법으로 스프링 스케줄러를 고려해봤습니다.
- 현재 시간상의 이유로 스케줄러로 고려했으나, 추후 유저가 늘어날 것을 대비해 메시지큐를 통해 동기화해볼 수도 있을 것 같습니다. 

**흐름**
1. Redis의 조회수 카운트를 가져옴
2. 해당하는 sharedNote에 update문을 통해 기존 조회수에 +N함
3. redis에서 해당 key값 제거

```java
	@Scheduled(cron = "0 0 */6 * * *") // 6시간마다 실행
	@Transactional
	public void syncRedisViewCountsToRDB() {
		Set<String> keys = redisTemplate.keys(VIEW_COUNT + "*");
		if (keys == null || keys.isEmpty())
			return;

		log.info("Redis RDB 조회수 동기화 시작: 총 {}개", keys.size());

		for (String key : keys) {
			try {
				long sharedNoteId = Long.parseLong(key.split(":")[2]);
				Object value = redisTemplate.opsForValue().get(key);
				if (value == null) {
					log.warn("조회수 값 없음 - key={}", key);
					continue;
				}
				long addAmount = Long.parseLong(value.toString());
				sharedNoteUpdater.updateViewCount(sharedNoteId, addAmount);
				log.info("조회수 동기화: sharedNoteId={}, Redis={}", sharedNoteId, addAmount);
				redisTemplate.delete(key);
			} catch (Exception e) {
				log.error("동기화 실패: key={}, error={}", key, e.getMessage(), e);
			}
		}
	}

```

