### PR TITLE
[feat/#343] 좋아요 등록 및 취소 API 구현

### DIFF
--- a/src/main/java/umc/th/juinjang/api/note/liked/controller/LikedNoteController.java
+++ b/src/main/java/umc/th/juinjang/api/note/liked/controller/LikedNoteController.java
@@ -1,0 +1,38 @@
+package umc.th.juinjang.api.note.liked.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.api.dto.ApiResponse;
+import umc.th.juinjang.api.note.liked.service.LikedNoteCommandService;
+import umc.th.juinjang.api.note.liked.service.response.LikedNoteDeleteResponse;
+import umc.th.juinjang.api.note.liked.service.response.LikedNotePostResponse;
+import umc.th.juinjang.domain.member.model.Member;
+
+@RestController
+@RequestMapping("/api/v2/shared-notes")
+@RequiredArgsConstructor
+public class LikedNoteController {
+
+	private final LikedNoteCommandService likedNoteCommandService;
+
+	@Operation(summary = "공유노트 좋아요 등록 API")
+	@PostMapping("/{sharedNoteId}/likes")
+	public ApiResponse<LikedNotePostResponse> createLikedNote(@AuthenticationPrincipal Member member,
+		@PathVariable("sharedNoteId") Long sharedNoteId) {
+		return ApiResponse.onSuccess(likedNoteCommandService.createLikedNote(member, sharedNoteId));
+	}
+
+	@Operation(summary = "공유노트 좋아요 취소 API")
+	@DeleteMapping("/{sharedNoteId}/likes")
+	public ApiResponse<LikedNoteDeleteResponse> deleteLikedNote(@AuthenticationPrincipal Member member,
+		@PathVariable("sharedNoteId") Long sharedNoteId) {
+		return ApiResponse.onSuccess(likedNoteCommandService.deleteLikedNote(member, sharedNoteId));
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/note/liked/service/LikedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/note/liked/service/LikedNoteCommandService.java
@@ -1,0 +1,47 @@
+package umc.th.juinjang.api.note.liked.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.api.note.liked.service.response.LikedNoteDeleteResponse;
+import umc.th.juinjang.api.note.liked.service.response.LikedNotePostResponse;
+import umc.th.juinjang.api.note.shared.service.SharedNoteFinder;
+import umc.th.juinjang.api.note.shared.service.SharedNoteUpdater;
+import umc.th.juinjang.domain.member.model.Member;
+import umc.th.juinjang.domain.note.liked.model.LikedNote;
+import umc.th.juinjang.domain.note.shared.model.SharedNote;
+
+@Service
+@RequiredArgsConstructor
+public class LikedNoteCommandService {
+
+	private final LikedNoteUpdater likedNoteUpdater;
+	private final SharedNoteFinder sharedNoteFinder;
+	private final SharedNoteUpdater sharedNoteUpdater;
+	private final LikedNoteFinder likedNoteFinder;
+	private final LikedNoteDeleter likedNoteDeleter;
+
+	@Transactional
+	public LikedNotePostResponse createLikedNote(Member member, Long sharedNoteId) {
+		SharedNote sharedNote = sharedNoteFinder.getById(sharedNoteId);
+		LikedNote likedNote = LikedNote.create(member, sharedNote);
+
+		likedNoteUpdater.save(likedNote);
+		sharedNoteUpdater.incrementLikedCountById(sharedNoteId);
+
+		return new LikedNotePostResponse(sharedNoteFinder.getLikedNoteById(sharedNoteId));
+	}
+
+	@Transactional
+	public LikedNoteDeleteResponse deleteLikedNote(Member member, Long sharedNoteId) {
+		SharedNote sharedNote = sharedNoteFinder.getById(sharedNoteId);
+		LikedNote likedNote = likedNoteFinder.getByMemberAndSharedNote(member, sharedNote);
+
+		likedNoteDeleter.delete(likedNote);
+		sharedNoteUpdater.decrementLikedCountById(sharedNoteId);
+
+		return new LikedNoteDeleteResponse(sharedNoteFinder.getLikedNoteById(sharedNoteId));
+	}
+
+}

--- a/src/main/java/umc/th/juinjang/api/note/liked/service/LikedNoteDeleter.java
+++ b/src/main/java/umc/th/juinjang/api/note/liked/service/LikedNoteDeleter.java
@@ -1,0 +1,18 @@
+package umc.th.juinjang.api.note.liked.service;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.domain.note.liked.model.LikedNote;
+import umc.th.juinjang.domain.note.liked.model.repository.LikedNoteRepository;
+
+@Component
+@RequiredArgsConstructor
+public class LikedNoteDeleter {
+
+	private final LikedNoteRepository likedNoteRepository;
+
+	void delete(LikedNote likedNote) {
+		likedNoteRepository.delete(likedNote);
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/note/liked/service/LikedNoteUpdater.java
+++ b/src/main/java/umc/th/juinjang/api/note/liked/service/LikedNoteUpdater.java
@@ -1,27 +1,27 @@
 package umc.th.juinjang.api.note.liked.service;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 import umc.th.juinjang.common.code.status.ErrorStatus;
 import umc.th.juinjang.common.exception.handler.LikedNoteHandler;
+import umc.th.juinjang.common.exception.handler.SharedNoteHandler;
 import umc.th.juinjang.domain.member.model.Member;
 import umc.th.juinjang.domain.note.liked.model.LikedNote;
 import umc.th.juinjang.domain.note.liked.model.repository.LikedNoteRepository;
-import umc.th.juinjang.domain.note.shared.model.SharedNote;
 
 @Component
 @RequiredArgsConstructor
-public class LikedNoteFinder {
+public class LikedNoteUpdater {
 
 	private final LikedNoteRepository likedNoteRepository;
 
-	public boolean existsByMemberAndSharedNote(Member member, SharedNote sharedNote) {
-		return likedNoteRepository.existsByMemberAndSharedNote(member, sharedNote);
-	}
-
-	public LikedNote getByMemberAndSharedNote(Member member, SharedNote sharedNote) {
-		return likedNoteRepository.findByMemberAndSharedNote(member, sharedNote)
-			.orElseThrow(() -> new LikedNoteHandler(ErrorStatus.LIKEDNOTE_NOT_FOUND));
+	public void save(LikedNote likedNote) {
+		try {
+			likedNoteRepository.save(likedNote);
+		} catch (DataIntegrityViolationException e) {
+			throw new LikedNoteHandler(ErrorStatus.LIKEDNOTE_CONFLICT);
+		}
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/note/liked/service/response/LikedNoteDeleteResponse.java
+++ b/src/main/java/umc/th/juinjang/api/note/liked/service/response/LikedNoteDeleteResponse.java
@@ -1,0 +1,4 @@
+package umc.th.juinjang.api.note.liked.service.response;
+
+public record LikedNoteDeleteResponse(Long count) {
+}

--- a/src/main/java/umc/th/juinjang/api/note/liked/service/response/LikedNotePostResponse.java
+++ b/src/main/java/umc/th/juinjang/api/note/liked/service/response/LikedNotePostResponse.java
@@ -1,0 +1,4 @@
+package umc.th.juinjang.api.note.liked.service.response;
+
+public record LikedNotePostResponse(long count) {
+}

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteFinder.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteFinder.java
@@ -16,7 +16,7 @@ public class SharedNoteFinder {
 
 	private final SharedNoteRepository sharedNoteRepository;
 
-	SharedNote getById(Long id) {
+	public SharedNote getById(Long id) {
 		return sharedNoteRepository.findById(id)
 			.orElseThrow(() -> new SharedNoteHandler(ErrorStatus.SHAREDNOTE_NOT_FOUND));
 	}
@@ -29,4 +29,9 @@ public class SharedNoteFinder {
 	Optional<SharedNote> findById(Long id) {
 		return sharedNoteRepository.findById(id);
 	}
+
+	public Long getLikedNoteById(Long id) {
+		return sharedNoteRepository.getLikeCountById(id);
+	}
+
 }

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteUpdater.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteUpdater.java
@@ -14,4 +14,12 @@ public class SharedNoteUpdater {
 	void updateViewCount(long sharedNoteId, long addAmount) {
 		sharedNoteRepository.incrementViewCount(sharedNoteId, addAmount);
 	}
+
+	public void incrementLikedCountById(Long sharedNoteId) {
+		sharedNoteRepository.incrementLikedCountById(sharedNoteId);
+	}
+
+	public void decrementLikedCountById(Long sharedNoteId) {
+		sharedNoteRepository.decrementLikedCountById(sharedNoteId);
+	}
 }

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/response/SharedNoteGetResponse.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/response/SharedNoteGetResponse.java
@@ -30,7 +30,7 @@ public record SharedNoteGetResponse(
 	String price,
 	String monthlyRent,
 	boolean isLiked,
-	int likedCount,
+	Long likedCount,
 	String period,
 	String updatedAt,
 	Long viewCount,

--- a/src/main/java/umc/th/juinjang/common/code/status/ErrorStatus.java
+++ b/src/main/java/umc/th/juinjang/common/code/status/ErrorStatus.java
@@ -104,10 +104,14 @@ public enum ErrorStatus implements BaseErrorCode {
 	// PencilAccount alert
 	PENCIL_ACCOUNT_NOT_FOUND(HttpStatus.BAD_REQUEST, "ACCOUNT4000", "멤버에 해당하는 계좌가 존재하지 않습니다."),
 
-	SHAREDNOTE_NOT_FOUND(HttpStatus.BAD_REQUEST, "SHAREDNOTE4000", "해당하는 공유노트가 존재하지 않습니다."),
+	SHAREDNOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "SHAREDNOTE4000", "해당하는 공유노트가 존재하지 않습니다."),
 	SHAREDNOTE_NOT_ENOUGH_PENCIL(HttpStatus.BAD_REQUEST, "SHAREDNOTE4001", "보유한 연필 수가 부족합니다."),
 	SHAREDNOTE_CONFLICT(HttpStatus.CONFLICT, "SHAREDNOTE4002", "이미 구매한 노트입니다."),
-	SHAREDNOTE_DEADLOCK(HttpStatus.LOCKED, "SHAREDNOTE4003", "잠시 후 다시 시도해주세요. 현재 다른 요청이 처리 중입니다.");
+	SHAREDNOTE_DEADLOCK(HttpStatus.LOCKED, "SHAREDNOTE4003", "잠시 후 다시 시도해주세요. 현재 다른 요청이 처리 중입니다."),
+
+	// LikedNote
+	LIKEDNOTE_CONFLICT(HttpStatus.CONFLICT, "LIKEDNOTE4000", "이미 좋아요한 노트입니다"),
+	LIKEDNOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "LIKEDNOTE4001", "이미 취소했거나 좋아요한 적이 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/umc/th/juinjang/common/exception/handler/LikedNoteHandler.java
+++ b/src/main/java/umc/th/juinjang/common/exception/handler/LikedNoteHandler.java
@@ -1,0 +1,10 @@
+package umc.th.juinjang.common.exception.handler;
+
+import umc.th.juinjang.common.code.BaseErrorCode;
+import umc.th.juinjang.common.exception.GeneralException;
+
+public class LikedNoteHandler extends GeneralException {
+	public LikedNoteHandler(BaseErrorCode code) {
+		super(code);
+	}
+}

--- a/src/main/java/umc/th/juinjang/domain/note/liked/model/LikedNote.java
+++ b/src/main/java/umc/th/juinjang/domain/note/liked/model/LikedNote.java
@@ -8,7 +8,10 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import umc.th.juinjang.domain.member.model.Member;
@@ -16,6 +19,14 @@ import umc.th.juinjang.domain.note.shared.model.SharedNote;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = {
+	@UniqueConstraint(
+		columnNames = {
+			"member_id",
+			"shared_note_id"
+		}
+	)
+})
 @Entity
 public class LikedNote {
 
@@ -30,5 +41,14 @@ public class LikedNote {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "shared_note_id", nullable = false)
 	private SharedNote sharedNote;
-	
+
+	@Builder
+	private LikedNote(Member member, SharedNote sharedNote) {
+		this.member = member;
+		this.sharedNote = sharedNote;
+	}
+
+	public static LikedNote create(Member member, SharedNote sharedNote) {
+		return LikedNote.builder().member(member).sharedNote(sharedNote).build();
+	}
 }

--- a/src/main/java/umc/th/juinjang/domain/note/liked/model/repository/LikedNoteRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/note/liked/model/repository/LikedNoteRepository.java
@@ -1,5 +1,7 @@
 package umc.th.juinjang.domain.note.liked.model.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import umc.th.juinjang.domain.member.model.Member;
@@ -9,4 +11,6 @@ import umc.th.juinjang.domain.note.shared.model.SharedNote;
 public interface LikedNoteRepository extends JpaRepository<LikedNote, Long> {
 
 	boolean existsByMemberAndSharedNote(Member member, SharedNote sharedNote);
+
+	Optional<LikedNote> findByMemberAndSharedNote(Member member, SharedNote sharedNote);
 }

--- a/src/main/java/umc/th/juinjang/domain/note/shared/model/SharedNote.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/model/SharedNote.java
@@ -53,7 +53,7 @@ public class SharedNote extends BaseEntity {
 	@Comment("임장 가격")
 	private Long price;
 
-	private int likeCount;
+	private Long likeCount;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "limjang_id", nullable = false, unique = true)
@@ -62,5 +62,9 @@ public class SharedNote extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id", nullable = false)
 	private Member member;
+
+	public Long increaseLikedCount() {
+		return this.likeCount = (likeCount == null ? 1L : likeCount + 1);
+	}
 }
 

--- a/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteRepository.java
@@ -17,4 +17,15 @@ public interface SharedNoteRepository extends JpaRepository<SharedNote, Long> {
 	@Modifying
 	@Query("UPDATE SharedNote s SET s.viewCount = COALESCE(s.viewCount, 0) + :addAmount WHERE s.sharedNoteId = :sharedNoteId")
 	void incrementViewCount(@Param("sharedNoteId") Long sharedNoteId, @Param("addAmount") Long addAmount);
+
+	@Modifying
+	@Query("UPDATE SharedNote sn SET sn.likeCount = sn.likeCount + 1 WHERE sn.sharedNoteId = :sharedNoteId")
+	void incrementLikedCountById(@Param("sharedNoteId") Long sharedNoteId);
+
+	@Query("SELECT sn.likeCount FROM SharedNote sn WHERE sn.sharedNoteId = :sharedNoteId")
+	Long getLikeCountById(@Param("sharedNoteId") Long sharedNoteId);
+
+	@Modifying
+	@Query("UPDATE SharedNote sn SET sn.likeCount = sn.likeCount - 1 WHERE sn.sharedNoteId = :sharedNoteId")
+	void decrementLikedCountById(@Param("sharedNoteId") Long sharedNoteId);
 }


### PR DESCRIPTION
## 작업내용

좋아요 등록 및 취소 API 구현

## 상세설명_ & 캡쳐

### 복합 키 유니크 제약 조건
좋아요 테이블의 (member_id, shared_note_id) 쌍으로 유니크 제약 조건을 걸어 중복 좋아요를 방지했습니다. 데이터 접근 객체에서 해당 에러 캐치하도록 처리했습니다.
 
```java
@Getter
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@Table(uniqueConstraints = {
	@UniqueConstraint(
		columnNames = {
			"member_id",
			"shared_note_id"
		}
	)
})
@Entity
public class LikedNote {
```

```java
@Component
@RequiredArgsConstructor
public class LikedNoteUpdater {

	private final LikedNoteRepository likedNoteRepository;

	public void save(LikedNote likedNote) {
		try {
			likedNoteRepository.save(likedNote);
		} catch (DataIntegrityViolationException e) {
			throw new LikedNoteHandler(ErrorStatus.LIKEDNOTE_CONFLICT);
		}
	}
}
```


### 총 좋아요 수 리턴 관련 


- JPA update 쿼리나가도 영속성 컨텍스트는 변경되지 않는 문제로 쿼리 한번 더 발생시켜 좋아요 수 재조회
- 엔티티에서 증가시키는 방향을 고민했으나 이 경우 다른 유저가 좋아요 눌렀을 경우 반영되지 않기 때문에 쿼리 한 번 더 나가게 했습니다. (맨 아래 sharedNoteFinder.getLikedNoteById 부분)
- 사실 이 부분은 동시성 문제가 더 있을 것 같은데 모든 API 구현 후 다시 확인하겠습니다. 

```java
	@Transactional
	public LikedNotePostResponse createLikedNote(Member member, Long sharedNoteId) {
		SharedNote sharedNote = sharedNoteFinder.getById(sharedNoteId);
		LikedNote likedNote = LikedNote.create(member, sharedNote);

		likedNoteUpdater.save(likedNote);
		sharedNoteUpdater.incrementLikedCountById(sharedNoteId);

		return new LikedNotePostResponse(sharedNoteFinder.getLikedNoteById(sharedNoteId));
	}
```