### PR TITLE
[feat/#333] 마이노트 상세 - 리포트 조회

### DIFF
--- a/src/main/java/umc/th/juinjang/api/checklist/controller/ChecklistControllerV2.java
+++ b/src/main/java/umc/th/juinjang/api/checklist/controller/ChecklistControllerV2.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import umc.th.juinjang.api.checklist.service.ChecklistQueryServiceV2;
 import umc.th.juinjang.api.checklist.service.response.ChecklistAnswerResponseDTO;
+import umc.th.juinjang.api.checklist.service.response.ReportResponseDTO;
 import umc.th.juinjang.api.dto.ApiResponse;
 
 import org.springframework.validation.annotation.Validated;
@@ -25,5 +26,13 @@ public class ChecklistControllerV2 {
 	public ApiResponse<List<ChecklistAnswerResponseDTO.AnswerDto>> getChecklistAnswer(
 		@PathVariable(name = "limjangId") Long noteId) {
 		return ApiResponse.onSuccess(checklistQueryService.getChecklistAnswerListByLimjang(noteId));
+	}
+
+	@CrossOrigin
+	@Operation(summary = "리포트 조회 V2")
+	@GetMapping("/report/{noteId}")
+	public ApiResponse<ReportResponseDTO.ReportV2DTO> getReport(
+		@PathVariable(name = "noteId") Long noteId) {
+		return ApiResponse.onSuccess(checklistQueryService.getReportByNoteId(noteId));
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/checklist/controller/ChecklistControllerV2.java
+++ b/src/main/java/umc/th/juinjang/api/checklist/controller/ChecklistControllerV2.java
@@ -23,7 +23,7 @@ public class ChecklistControllerV2 {
 	@Operation(summary = "체크리스트 답변 조회")
 	@GetMapping("/checklist/{limjangId}")
 	public ApiResponse<List<ChecklistAnswerResponseDTO.AnswerDto>> getChecklistAnswer(
-		@PathVariable(name = "limjangId") Long limjangId) {
-		return ApiResponse.onSuccess(checklistQueryService.getChecklistAnswerListByLimjang(limjangId));
+		@PathVariable(name = "limjangId") Long noteId) {
+		return ApiResponse.onSuccess(checklistQueryService.getChecklistAnswerListByLimjang(noteId));
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/checklist/service/ChecklistAnswerFinder.java
+++ b/src/main/java/umc/th/juinjang/api/checklist/service/ChecklistAnswerFinder.java
@@ -21,8 +21,8 @@ public class ChecklistAnswerFinder {
 	private final ChecklistAnswerRepository checklistAnswerRepository;
 	private final LimjangRepository limjangRepository;
 
-	public List<ChecklistAnswerResponseDTO.AnswerDto> findByLimjangId(Long limjangId) {
-		Limjang limjang = limjangRepository.findByLimjangIdAndDeletedIsFalse(limjangId)
+	public List<ChecklistAnswerResponseDTO.AnswerDto> findByLimjangId(Long noteId) {
+		Limjang limjang = limjangRepository.findByLimjangIdAndDeletedIsFalse(noteId)
 			.orElseThrow(() -> new LimjangHandler(ErrorStatus.LIMJANG_NOTFOUND_ERROR));
 
 		List<ChecklistAnswer> answerList = checklistAnswerRepository.findChecklistAnswerByLimjangId(limjang);

--- a/src/main/java/umc/th/juinjang/api/checklist/service/ChecklistQueryServiceV2.java
+++ b/src/main/java/umc/th/juinjang/api/checklist/service/ChecklistQueryServiceV2.java
@@ -27,9 +27,13 @@ import umc.th.juinjang.domain.report.repository.ReportRepository;
 public class ChecklistQueryServiceV2 {
 
 	private final ChecklistAnswerFinder checklistAnswerFinder;
+	private final ChecklistReportFinder checklistReportFinder;
 
 	public List<ChecklistAnswerResponseDTO.AnswerDto> getChecklistAnswerListByLimjang(Long noteId) {
 		return checklistAnswerFinder.findByLimjangId(noteId);
 	}
 
+	public ReportResponseDTO.ReportV2DTO getReportByNoteId(Long noteId) {
+		return checklistReportFinder.findReportByNoteId(noteId);
+	}
 }

--- a/src/main/java/umc/th/juinjang/api/checklist/service/ChecklistQueryServiceV2.java
+++ b/src/main/java/umc/th/juinjang/api/checklist/service/ChecklistQueryServiceV2.java
@@ -1,25 +1,17 @@
 package umc.th.juinjang.api.checklist.service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import umc.th.juinjang.api.checklist.service.converter.ChecklistAnswerAndReportConverter;
+import umc.th.juinjang.api.checklist.service.converter.ReportConverter;
 import umc.th.juinjang.api.checklist.service.response.ChecklistAnswerResponseDTO;
 import umc.th.juinjang.api.checklist.service.response.ReportResponseDTO;
-import umc.th.juinjang.common.code.status.ErrorStatus;
-import umc.th.juinjang.common.exception.handler.ChecklistHandler;
-import umc.th.juinjang.common.exception.handler.LimjangHandler;
-import umc.th.juinjang.domain.checklist.model.ChecklistAnswer;
-import umc.th.juinjang.domain.checklist.repository.ChecklistAnswerRepository;
-import umc.th.juinjang.domain.checklist.repository.ChecklistQuestionRepository;
+import umc.th.juinjang.api.limjang.service.NoteFinder;
 import umc.th.juinjang.domain.limjang.model.Limjang;
-import umc.th.juinjang.domain.limjang.repository.LimjangRepository;
 import umc.th.juinjang.domain.report.model.Report;
-import umc.th.juinjang.domain.report.repository.ReportRepository;
 
 @Slf4j
 @Service
@@ -27,13 +19,16 @@ import umc.th.juinjang.domain.report.repository.ReportRepository;
 public class ChecklistQueryServiceV2 {
 
 	private final ChecklistAnswerFinder checklistAnswerFinder;
-	private final ChecklistReportFinder checklistReportFinder;
+	private final ReportFinder reportFinder;
+	private final NoteFinder noteFinder;
 
 	public List<ChecklistAnswerResponseDTO.AnswerDto> getChecklistAnswerListByLimjang(Long noteId) {
 		return checklistAnswerFinder.findByLimjangId(noteId);
 	}
 
 	public ReportResponseDTO.ReportV2DTO getReportByNoteId(Long noteId) {
-		return checklistReportFinder.findReportByNoteId(noteId);
+		Limjang limjang = noteFinder.getNoteByIdWhereDeletedIsFalse(noteId);
+		Report report = reportFinder.findReportByNote(limjang);
+		return ReportConverter.toReportV2Dto(report, limjang);
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/checklist/service/ChecklistQueryServiceV2.java
+++ b/src/main/java/umc/th/juinjang/api/checklist/service/ChecklistQueryServiceV2.java
@@ -28,8 +28,8 @@ public class ChecklistQueryServiceV2 {
 
 	private final ChecklistAnswerFinder checklistAnswerFinder;
 
-	public List<ChecklistAnswerResponseDTO.AnswerDto> getChecklistAnswerListByLimjang(Long limjangId) {
-		return checklistAnswerFinder.findByLimjangId(limjangId);
+	public List<ChecklistAnswerResponseDTO.AnswerDto> getChecklistAnswerListByLimjang(Long noteId) {
+		return checklistAnswerFinder.findByLimjangId(noteId);
 	}
 
 }

--- a/src/main/java/umc/th/juinjang/api/checklist/service/ChecklistReportFinder.java
+++ b/src/main/java/umc/th/juinjang/api/checklist/service/ChecklistReportFinder.java
@@ -1,0 +1,33 @@
+package umc.th.juinjang.api.checklist.service;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Component;
+
+import umc.th.juinjang.api.checklist.service.converter.ChecklistAnswerAndReportConverter;
+import umc.th.juinjang.api.checklist.service.response.ReportResponseDTO;
+import umc.th.juinjang.common.code.status.ErrorStatus;
+import umc.th.juinjang.common.exception.handler.ChecklistHandler;
+import umc.th.juinjang.common.exception.handler.LimjangHandler;
+import umc.th.juinjang.domain.limjang.model.Limjang;
+import umc.th.juinjang.domain.limjang.repository.LimjangRepository;
+import umc.th.juinjang.domain.report.model.Report;
+import umc.th.juinjang.domain.report.repository.ReportRepository;
+
+@Component
+@RequiredArgsConstructor
+public class ChecklistReportFinder {
+
+	private final LimjangRepository limjangRepository;
+	private final ReportRepository reportRepository;
+
+	public ReportResponseDTO.ReportV2DTO findReportByNoteId(Long noteId) {
+		Limjang limjang = limjangRepository.findByLimjangIdAndDeletedIsFalse(noteId)
+			.orElseThrow(() -> new LimjangHandler(ErrorStatus.LIMJANG_NOTFOUND_ERROR));
+
+		Report report = reportRepository.findByLimjangId(limjang)
+			.orElseThrow(() -> new ChecklistHandler(ErrorStatus.REPORT_NOTFOUND_ERROR));
+
+		return ChecklistAnswerAndReportConverter.toReportV2Dto(report, limjang);
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/checklist/service/ChecklistReportFinder.java
+++ b/src/main/java/umc/th/juinjang/api/checklist/service/ChecklistReportFinder.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import umc.th.juinjang.api.checklist.service.converter.ChecklistAnswerAndReportConverter;
+import umc.th.juinjang.api.checklist.service.converter.ReportConverter;
 import umc.th.juinjang.api.checklist.service.response.ReportResponseDTO;
 import umc.th.juinjang.common.code.status.ErrorStatus;
 import umc.th.juinjang.common.exception.handler.ChecklistHandler;
@@ -28,6 +29,6 @@ public class ChecklistReportFinder {
 		Report report = reportRepository.findByLimjangId(limjang)
 			.orElseThrow(() -> new ChecklistHandler(ErrorStatus.REPORT_NOTFOUND_ERROR));
 
-		return ChecklistAnswerAndReportConverter.toReportV2Dto(report, limjang);
+		return ReportConverter.toReportV2Dto(report, limjang);
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/checklist/service/ReportFinder.java
+++ b/src/main/java/umc/th/juinjang/api/checklist/service/ReportFinder.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Component;
 
-import umc.th.juinjang.api.checklist.service.converter.ChecklistAnswerAndReportConverter;
 import umc.th.juinjang.api.checklist.service.converter.ReportConverter;
 import umc.th.juinjang.api.checklist.service.response.ReportResponseDTO;
 import umc.th.juinjang.common.code.status.ErrorStatus;
@@ -17,18 +16,11 @@ import umc.th.juinjang.domain.report.repository.ReportRepository;
 
 @Component
 @RequiredArgsConstructor
-public class ChecklistReportFinder {
-
-	private final LimjangRepository limjangRepository;
+public class ReportFinder {
 	private final ReportRepository reportRepository;
 
-	public ReportResponseDTO.ReportV2DTO findReportByNoteId(Long noteId) {
-		Limjang limjang = limjangRepository.findByLimjangIdAndDeletedIsFalse(noteId)
-			.orElseThrow(() -> new LimjangHandler(ErrorStatus.LIMJANG_NOTFOUND_ERROR));
-
-		Report report = reportRepository.findByLimjangId(limjang)
+	public Report findReportByNote(Limjang limjang) {
+		return reportRepository.findByLimjangId(limjang)
 			.orElseThrow(() -> new ChecklistHandler(ErrorStatus.REPORT_NOTFOUND_ERROR));
-
-		return ReportConverter.toReportV2Dto(report, limjang);
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/checklist/service/converter/ChecklistAnswerAndReportConverter.java
+++ b/src/main/java/umc/th/juinjang/api/checklist/service/converter/ChecklistAnswerAndReportConverter.java
@@ -58,19 +58,4 @@ public class ChecklistAnswerAndReportConverter {
 		return new ReportResponseDTO(reportDTO, detailDto);
 	}
 
-	public static ReportResponseDTO.ReportV2DTO toReportV2Dto(Report report, Limjang limjang) {
-		ReportResponseDTO.ReportV2DTO reportDTO = ReportResponseDTO.ReportV2DTO.builder()
-			.reportId(report.getReportId())
-			.indoorKeyWord(report.getIndoorKeyword())
-			.publicSpaceKeyWord(report.getPublicSpaceKeyword())
-			.locationConditionsWord(report.getLocationConditionsKeyword())
-			.indoorRate(report.getIndoorRate())
-			.publicSpaceRate(report.getPublicSpaceRate())
-			.locationConditionsRate(report.getLocationConditionsRate())
-			.totalRate(report.getTotalRate())
-			.limjangId(limjang.getLimjangId())
-			.build();
-		return reportDTO;
-	}
-
 }

--- a/src/main/java/umc/th/juinjang/api/checklist/service/converter/ChecklistAnswerAndReportConverter.java
+++ b/src/main/java/umc/th/juinjang/api/checklist/service/converter/ChecklistAnswerAndReportConverter.java
@@ -14,44 +14,63 @@ import java.util.stream.Collectors;
 
 public class ChecklistAnswerAndReportConverter {
 
-    public static ChecklistAnswerAndReportResponseDTO toDto(List<ChecklistAnswer> answerList, Report report, Limjang limjang) {
-        List<ChecklistAnswerResponseDTO.AnswerDto> answerDtoList = answerList.stream()
-                .map(answer -> new ChecklistAnswerResponseDTO.AnswerDto(
-                        answer.getAnswerId(),
-                        answer.getQuestionId().getQuestionId(),
-                        //answer.getQuestionId().getCategory(),
-                        answer.getLimjangId().getLimjangId(),
-                        answer.getAnswer(),
-                        answer.getQuestionId().getAnswerType()))
-                .collect(Collectors.toList());
+	public static ChecklistAnswerAndReportResponseDTO toDto(List<ChecklistAnswer> answerList, Report report,
+		Limjang limjang) {
+		List<ChecklistAnswerResponseDTO.AnswerDto> answerDtoList = answerList.stream()
+			.map(answer -> new ChecklistAnswerResponseDTO.AnswerDto(
+				answer.getAnswerId(),
+				answer.getQuestionId().getQuestionId(),
+				//answer.getQuestionId().getCategory(),
+				answer.getLimjangId().getLimjangId(),
+				answer.getAnswer(),
+				answer.getQuestionId().getAnswerType()))
+			.collect(Collectors.toList());
 
-        ReportResponseDTO.ReportDTO reportDto = new ReportResponseDTO.ReportDTO(
-                report.getReportId(),
-                report.getIndoorKeyword(),
-                report.getPublicSpaceKeyword(),
-                report.getLocationConditionsKeyword(),
-                report.getIndoorRate(),
-                report.getPublicSpaceRate(),
-                report.getLocationConditionsRate(),
-                report.getTotalRate());
+		ReportResponseDTO.ReportDTO reportDto = new ReportResponseDTO.ReportDTO(
+			report.getReportId(),
+			report.getIndoorKeyword(),
+			report.getPublicSpaceKeyword(),
+			report.getLocationConditionsKeyword(),
+			report.getIndoorRate(),
+			report.getPublicSpaceRate(),
+			report.getLocationConditionsRate(),
+			report.getTotalRate());
 
-        LimjangDetailResponseDTO.DetailDto detailDto = LimjangDetailConverter.toDetail(limjang, limjang.getLimjangPrice());
+		LimjangDetailResponseDTO.DetailDto detailDto = LimjangDetailConverter.toDetail(limjang,
+			limjang.getLimjangPrice());
 
-        return new ChecklistAnswerAndReportResponseDTO(answerDtoList, new ReportResponseDTO(reportDto, detailDto));
-    }
-    public static ReportResponseDTO toReportDto(Report report, Limjang limjang) {
-        ReportResponseDTO.ReportDTO reportDTO = ReportResponseDTO.ReportDTO.builder()
-                .reportId(report.getReportId())
-                .indoorKeyWord(report.getIndoorKeyword())
-                .publicSpaceKeyWord(report.getPublicSpaceKeyword())
-                .locationConditionsWord(report.getLocationConditionsKeyword())
-                .indoorRate(report.getIndoorRate())
-                .publicSpaceRate(report.getPublicSpaceRate())
-                .locationConditionsRate(report.getLocationConditionsRate())
-                .totalRate(report.getTotalRate())
-                .build();
-        LimjangDetailResponseDTO.DetailDto detailDto = LimjangDetailConverter.toDetail(limjang, limjang.getLimjangPrice());
-        return new ReportResponseDTO(reportDTO, detailDto);
-    }
+		return new ChecklistAnswerAndReportResponseDTO(answerDtoList, new ReportResponseDTO(reportDto, detailDto));
+	}
+
+	public static ReportResponseDTO toReportDto(Report report, Limjang limjang) {
+		ReportResponseDTO.ReportDTO reportDTO = ReportResponseDTO.ReportDTO.builder()
+			.reportId(report.getReportId())
+			.indoorKeyWord(report.getIndoorKeyword())
+			.publicSpaceKeyWord(report.getPublicSpaceKeyword())
+			.locationConditionsWord(report.getLocationConditionsKeyword())
+			.indoorRate(report.getIndoorRate())
+			.publicSpaceRate(report.getPublicSpaceRate())
+			.locationConditionsRate(report.getLocationConditionsRate())
+			.totalRate(report.getTotalRate())
+			.build();
+		LimjangDetailResponseDTO.DetailDto detailDto = LimjangDetailConverter.toDetail(limjang,
+			limjang.getLimjangPrice());
+		return new ReportResponseDTO(reportDTO, detailDto);
+	}
+
+	public static ReportResponseDTO.ReportV2DTO toReportV2Dto(Report report, Limjang limjang) {
+		ReportResponseDTO.ReportV2DTO reportDTO = ReportResponseDTO.ReportV2DTO.builder()
+			.reportId(report.getReportId())
+			.indoorKeyWord(report.getIndoorKeyword())
+			.publicSpaceKeyWord(report.getPublicSpaceKeyword())
+			.locationConditionsWord(report.getLocationConditionsKeyword())
+			.indoorRate(report.getIndoorRate())
+			.publicSpaceRate(report.getPublicSpaceRate())
+			.locationConditionsRate(report.getLocationConditionsRate())
+			.totalRate(report.getTotalRate())
+			.limjangId(limjang.getLimjangId())
+			.build();
+		return reportDTO;
+	}
 
 }

--- a/src/main/java/umc/th/juinjang/api/checklist/service/converter/ReportConverter.java
+++ b/src/main/java/umc/th/juinjang/api/checklist/service/converter/ReportConverter.java
@@ -1,0 +1,32 @@
+package umc.th.juinjang.api.checklist.service.converter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import umc.th.juinjang.api.checklist.service.response.ChecklistAnswerAndReportResponseDTO;
+import umc.th.juinjang.api.checklist.service.response.ChecklistAnswerResponseDTO;
+import umc.th.juinjang.api.checklist.service.response.ReportResponseDTO;
+import umc.th.juinjang.api.limjang.service.converter.LimjangDetailConverter;
+import umc.th.juinjang.api.limjang.service.response.LimjangDetailResponseDTO;
+import umc.th.juinjang.domain.checklist.model.ChecklistAnswer;
+import umc.th.juinjang.domain.limjang.model.Limjang;
+import umc.th.juinjang.domain.report.model.Report;
+
+public class ReportConverter {
+
+	public static ReportResponseDTO.ReportV2DTO toReportV2Dto(Report report, Limjang limjang) {
+		ReportResponseDTO.ReportV2DTO reportDTO = ReportResponseDTO.ReportV2DTO.builder()
+			.reportId(report.getReportId())
+			.indoorKeyWord(report.getIndoorKeyword())
+			.publicSpaceKeyWord(report.getPublicSpaceKeyword())
+			.locationConditionsWord(report.getLocationConditionsKeyword())
+			.indoorRate(report.getIndoorRate())
+			.publicSpaceRate(report.getPublicSpaceRate())
+			.locationConditionsRate(report.getLocationConditionsRate())
+			.totalRate(report.getTotalRate())
+			.limjangId(limjang.getLimjangId())
+			.build();
+		return reportDTO;
+	}
+
+}

--- a/src/main/java/umc/th/juinjang/api/checklist/service/response/ReportResponseDTO.java
+++ b/src/main/java/umc/th/juinjang/api/checklist/service/response/ReportResponseDTO.java
@@ -7,22 +7,39 @@ import umc.th.juinjang.api.limjang.service.response.LimjangDetailResponseDTO;
 @Getter
 @Setter
 public class ReportResponseDTO {
-    private ReportDTO reportDTO;
-    private LimjangDetailResponseDTO.DetailDto limjangDto;
+	private ReportDTO reportDTO;
+	private LimjangDetailResponseDTO.DetailDto limjangDto;
 
-    @Getter
-    @Setter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Builder
-    public static class ReportDTO {
-        private Long reportId;
-        private String indoorKeyWord;
-        private String publicSpaceKeyWord;
-        private String locationConditionsWord;
-        private Float indoorRate;
-        private Float publicSpaceRate;
-        private Float locationConditionsRate;
-        private Float totalRate;
-    }
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	public static class ReportDTO {
+		private Long reportId;
+		private String indoorKeyWord;
+		private String publicSpaceKeyWord;
+		private String locationConditionsWord;
+		private Float indoorRate;
+		private Float publicSpaceRate;
+		private Float locationConditionsRate;
+		private Float totalRate;
+	}
+
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	public static class ReportV2DTO {
+		private Long reportId;
+		private String indoorKeyWord;
+		private String publicSpaceKeyWord;
+		private String locationConditionsWord;
+		private Float indoorRate;
+		private Float publicSpaceRate;
+		private Float locationConditionsRate;
+		private Float totalRate;
+		private Long limjangId;
+	}
 }

--- a/src/main/java/umc/th/juinjang/api/limjang/service/NoteFinder.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/service/NoteFinder.java
@@ -22,7 +22,7 @@ public class NoteFinder {
 		return limjangRepository.findAllByMemberAndDeletedIsFalseOrderByParamV2(member, sortOptions);
 	}
 
-	protected Limjang getNoteByIdWhereDeletedIsFalse(long id) {
+	public Limjang getNoteByIdWhereDeletedIsFalse(long id) {
 		return limjangRepository.findByLimjangIdAndDeletedIsFalse(id)
 			.orElseThrow(() -> new LimjangHandler(ErrorStatus.LIMJANG_NOTFOUND_ERROR));
 	}


### PR DESCRIPTION
## 작업내용
- 이전 체크리스트 조회 부분에서 V2부터 쓰기로 한 noteId 대신 limjangId 쓴 것을 발견해 이 부분 바꾸었습니다.
- finder 사용해서 구현하였고 reportDTO에서 이전 버전에 있던 Limjang 관련 부분은 제외하고 limjangId만 추가해 DTO 구성하였습니다.

## 상세설명_ & 캡쳐
![image](https://github.com/user-attachments/assets/f8f72e90-7630-4b9e-b21d-df966d8ee193)
service 부분에서 notefinder, reportfinder 호출한 후 converter 사용해 응답값 생성
(이 과정에서 noteFinder 사용을 위해 관련된 함수만 protected -> public으로 변경하였습니다. @PicturePark1101 감사합니다.)

![image](https://github.com/user-attachments/assets/70e535b8-3db6-401b-922f-1aa6076c76ca)
스웨거로 테스트한 결과입니다.