### PR TITLE
[feat/#336] safe search 및 노트 공유하기 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,5 @@ out/
 /src/main/resources/application.yml
 /src/main/resources/application-dev.yml
 /src/main/resources/application-prod.yml
+/src/main/resources/*.json
 /src/main/generated/*

--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,8 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    //Safe Search
+    implementation 'com.google.cloud:google-cloud-vision:3.58.0'
 
 }
 

--- a/src/main/java/umc/th/juinjang/api/limjang/service/NoteFinder.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/service/NoteFinder.java
@@ -22,7 +22,7 @@ public class NoteFinder {
 		return limjangRepository.findAllByMemberAndDeletedIsFalseOrderByParamV2(member, sortOptions);
 	}
 
-	protected Limjang getNoteByIdWhereDeletedIsFalse(long id) {
+	public Limjang getNoteByIdWhereDeletedIsFalse(long id) {
 		return limjangRepository.findByLimjangIdAndDeletedIsFalse(id)
 			.orElseThrow(() -> new LimjangHandler(ErrorStatus.LIMJANG_NOTFOUND_ERROR));
 	}

--- a/src/main/java/umc/th/juinjang/api/limjang/service/NoteUpdater.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/service/NoteUpdater.java
@@ -12,7 +12,7 @@ public class NoteUpdater {
 
 	private final LimjangRepository limjangRepository;
 
-	protected void save(Limjang limjang) {
+	public void save(Limjang limjang) {
 		limjangRepository.save(limjang);
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/note/shared/controller/SharedNoteController.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/controller/SharedNoteController.java
@@ -4,12 +4,14 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import umc.th.juinjang.api.dto.ApiResponse;
+import umc.th.juinjang.api.note.shared.controller.request.SharedNotePostRequest;
 import umc.th.juinjang.api.note.shared.service.SharedNoteCommandService;
 import umc.th.juinjang.api.note.shared.service.SharedNoteQueryService;
 import umc.th.juinjang.api.note.shared.service.response.SharedNoteGetResponse;
@@ -38,4 +40,12 @@ public class SharedNoteController {
 		return ApiResponse.onSuccess(sharedNoteQueryService.findSharedNote(member, sharedNoteId));
 	}
 
+	@Operation(summary = "공유 노트 생성 API")
+	@PostMapping("/{noteId}")
+	public ApiResponse<Void> uploadSharedNote(@AuthenticationPrincipal Member member,
+		@PathVariable("noteId") Long noteId,
+		@RequestBody SharedNotePostRequest request) {
+		sharedNoteCommandService.createSharedNote(member, noteId, request);
+		return ApiResponse.onSuccess(null);
+	}
 }

--- a/src/main/java/umc/th/juinjang/api/note/shared/controller/request/SharedNotePostRequest.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/controller/request/SharedNotePostRequest.java
@@ -1,0 +1,14 @@
+package umc.th.juinjang.api.note.shared.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record SharedNotePostRequest(
+	@NotBlank String buildingName,
+	@NotBlank String review,
+	@NotNull Integer year,
+	@NotNull Integer month,
+	@NotBlank String period,
+	@NotNull Long price
+) {
+}

--- a/src/main/java/umc/th/juinjang/api/note/shared/controller/request/SharedNotePostRequest.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/controller/request/SharedNotePostRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotNull;
 public record SharedNotePostRequest(
 	@NotBlank String buildingName,
 	@NotBlank String review,
+	@NotNull Boolean isImageShared,
 	@NotNull Integer year,
 	@NotNull Integer month,
 	@NotBlank String period,

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
@@ -88,6 +88,10 @@ public class SharedNoteCommandService {
 		return AcquiredPencil.create(seller, "", sharedNoteId, price, false, AcquiredType.SOLD);
 	}
 
+	private AcquiredPencil createNoteSharedAcquiredPencil(Long sharedNoteId, Member member, Long price) {
+		return AcquiredPencil.create(member, "", sharedNoteId, price, false, AcquiredType.NOTE);
+	}
+
 	private UsedPencil createUsedPencil(Member member, Long sharedNoteId, SharedNote sharedNote,
 		PencilAccount buyerAccount) {
 		return UsedPencil.create(member, sharedNoteId, sharedNote.getPrice(), Usedtype.OWNED,
@@ -135,5 +139,9 @@ public class SharedNoteCommandService {
 		sharedNoteUpdater.save(sharedNote);
 
 		//사용자 지갑에 rewardPencil만큼 업데이트
+		PencilAccount pencilAccount = pencilAccountFinder.findByMemberWithLock(member);
+		pencilAccount.increaseAcquiredBalance(rewardPencilCount);
+		acquiredPencilUpdater.save(
+			createNoteSharedAcquiredPencil(sharedNote.getSharedNoteId(), member, rewardPencilCount.longValue()));
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
@@ -1,5 +1,8 @@
 package umc.th.juinjang.api.note.shared.service;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 import org.hibernate.exception.LockAcquisitionException;
 import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.stereotype.Service;
@@ -97,9 +100,16 @@ public class SharedNoteCommandService {
 	@Transactional
 	public void createSharedNote(Member member, Long noteId, SharedNotePostRequest request) {
 		Integer rewardPencilCount = 0;
-		//이미 공유된 임장인지 확인
-		if (sharedNoteFinder.existsByLimjangId(noteId)) {
-			throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_ALREADY_EXISTS);
+
+		Optional<SharedNote> maybeNote = sharedNoteFinder.findLatestByLimjangId(noteId);
+		if (maybeNote.isPresent()) {
+			SharedNote note = maybeNote.get();
+			if (note.getDeletedAt() == null) {
+				throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_ALREADY_EXISTS);
+			}
+			if (note.getDeletedAt().toLocalDateTime().isAfter(LocalDateTime.now().minusMonths(6))) {
+				throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_DELETED_RECENTLY);
+			}
 		}
 
 		//Limjang 조회

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
@@ -7,12 +7,15 @@ import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.persistence.PessimisticLockException;
 import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.api.limjang.service.NoteFinder;
+import umc.th.juinjang.api.note.shared.controller.request.SharedNotePostRequest;
 import umc.th.juinjang.api.pencil.service.AcquiredPencilUpdater;
 import umc.th.juinjang.api.pencil.service.UsedPencilFinder;
 import umc.th.juinjang.api.pencil.service.UsedPencilUpdater;
 import umc.th.juinjang.api.pencilAccount.service.PencilAccountFinder;
 import umc.th.juinjang.common.code.status.ErrorStatus;
 import umc.th.juinjang.common.exception.handler.SharedNoteHandler;
+import umc.th.juinjang.domain.limjang.model.Limjang;
 import umc.th.juinjang.domain.member.model.Member;
 import umc.th.juinjang.domain.note.shared.model.SharedNote;
 import umc.th.juinjang.domain.pencil.acquired.model.AcquiredPencil;
@@ -30,6 +33,8 @@ public class SharedNoteCommandService {
 	private final UsedPencilFinder usedPencilFinder;
 	private final AcquiredPencilUpdater acquiredPencilUpdater;
 	private final PencilAccountFinder pencilAccountFinder;
+	private final NoteFinder noteFinder;
+	private final SharedNoteUpdater sharedNoteUpdater;
 
 	@Transactional
 	public void createSharedNotePurchase(Member buyer, Long sharedNoteId) {
@@ -81,5 +86,17 @@ public class SharedNoteCommandService {
 		PencilAccount buyerAccount) {
 		return UsedPencil.create(member, sharedNoteId, sharedNote.getPrice(), Usedtype.OWNED,
 			sharedNote.getBuildingName(), buyerAccount.getTotalBalance());
+	}
+
+	@Transactional
+	public void createSharedNote(Member member, Long noteId, SharedNotePostRequest request) {
+
+		if (sharedNoteFinder.existsByLimjangId(noteId)) {
+			throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_ALREADY_EXISTS);
+		}
+		Limjang limjang = noteFinder.getNoteByIdWhereDeletedIsFalse(noteId);
+		
+		SharedNote sharedNote = SharedNote.toSharedNote(member, limjang, request);
+		sharedNoteUpdater.save(sharedNote);
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
@@ -121,11 +121,11 @@ public class SharedNoteCommandService {
 			for (var image : limjang.getImageList()) {
 				boolean safe = safeSearchClient.isSafeImage(
 					image.getImageUrl(),
-					Likelihood.VERY_LIKELY,  // adult
-					Likelihood.VERY_LIKELY,  // spoof
-					Likelihood.VERY_LIKELY,  // medical
-					Likelihood.VERY_LIKELY,  // violence
-					Likelihood.VERY_LIKELY   // racy
+					Likelihood.UNLIKELY,  // adult
+					Likelihood.POSSIBLE,  // spoof
+					Likelihood.POSSIBLE,  // medical
+					Likelihood.UNLIKELY,  // violence
+					Likelihood.LIKELY   // racy
 				);
 				if (!safe) {
 					throw new SharedNoteHandler(ErrorStatus.SHARED_NOT_ALLOWED);

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
@@ -101,9 +101,9 @@ public class SharedNoteCommandService {
 	public void createSharedNote(Member member, Long noteId, SharedNotePostRequest request) {
 		Integer rewardPencilCount = 0;
 
-		Optional<SharedNote> maybeNote = sharedNoteFinder.findLatestByLimjangId(noteId);
-		if (maybeNote.isPresent()) {
-			SharedNote note = maybeNote.get();
+		Optional<SharedNote> latestSharedNote = sharedNoteFinder.findLatestByLimjangId(noteId);
+		if (latestSharedNote.isPresent()) {
+			SharedNote note = latestSharedNote.get();
 			if (note.getDeletedAt() == null) {
 				throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_ALREADY_EXISTS);
 			}

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
@@ -5,6 +5,8 @@ import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.google.cloud.vision.v1.Likelihood;
+
 import jakarta.persistence.PessimisticLockException;
 import lombok.RequiredArgsConstructor;
 import umc.th.juinjang.api.limjang.service.NoteFinder;
@@ -23,6 +25,7 @@ import umc.th.juinjang.domain.pencil.acquired.model.AcquiredType;
 import umc.th.juinjang.domain.pencil.used.model.UsedPencil;
 import umc.th.juinjang.domain.pencil.used.model.Usedtype;
 import umc.th.juinjang.domain.pencilaccount.model.PencilAccount;
+import umc.th.juinjang.safeSearch.SafeSearchClient;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +38,7 @@ public class SharedNoteCommandService {
 	private final PencilAccountFinder pencilAccountFinder;
 	private final NoteFinder noteFinder;
 	private final SharedNoteUpdater sharedNoteUpdater;
+	private final SafeSearchClient safeSearchClient;
 
 	@Transactional
 	public void createSharedNotePurchase(Member buyer, Long sharedNoteId) {
@@ -90,12 +94,30 @@ public class SharedNoteCommandService {
 
 	@Transactional
 	public void createSharedNote(Member member, Long noteId, SharedNotePostRequest request) {
-
+		//이미 공유된 임장인지 확인
 		if (sharedNoteFinder.existsByLimjangId(noteId)) {
 			throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_ALREADY_EXISTS);
 		}
+
+		//Limjang 조회
 		Limjang limjang = noteFinder.getNoteByIdWhereDeletedIsFalse(noteId);
-		
+
+		//SafeSearch 검사 (유해 이미지가 하나라도 있으면 차단)
+		for (var image : limjang.getImageList()) {
+			boolean safe = safeSearchClient.isSafeImage(
+				image.getImageUrl(),
+				Likelihood.VERY_LIKELY,  // adult
+				Likelihood.VERY_LIKELY,  // spoof
+				Likelihood.VERY_LIKELY,  // medical
+				Likelihood.VERY_LIKELY,  // violence
+				Likelihood.VERY_LIKELY   // racy
+			);
+			if (!safe) {
+				throw new SharedNoteHandler(ErrorStatus.SHARED_NOT_ALLOWED);
+			}
+		}
+
+		//저장
 		SharedNote sharedNote = SharedNote.toSharedNote(member, limjang, request);
 		sharedNoteUpdater.save(sharedNote);
 	}

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
@@ -57,7 +57,7 @@ public class SharedNoteCommandService {
 			executePayment(buyerAccount, sellerAccount, price);
 
 			usedPencilUpdater.save(createUsedPencil(buyer, sharedNoteId, sharedNote, buyerAccount));
-			acquiredPencilUpdater.save(createAcquiredPencil(sharedNoteId, seller, price));
+			acquiredPencilUpdater.save(createAcquiredPencil(sharedNoteId, seller, price, AcquiredType.SOLD));
 		} catch (CannotAcquireLockException | PessimisticLockException | LockAcquisitionException e) {
 			throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_DEADLOCK);
 		}
@@ -84,12 +84,8 @@ public class SharedNoteCommandService {
 		sellerAccount.increaseAcquiredBalance(price);
 	}
 
-	private AcquiredPencil createAcquiredPencil(Long sharedNoteId, Member seller, Long price) {
-		return AcquiredPencil.create(seller, "", sharedNoteId, price, false, AcquiredType.SOLD);
-	}
-
-	private AcquiredPencil createNoteSharedAcquiredPencil(Long sharedNoteId, Member member, Long price) {
-		return AcquiredPencil.create(member, "", sharedNoteId, price, false, AcquiredType.NOTE);
+	private AcquiredPencil createAcquiredPencil(Long sharedNoteId, Member seller, Long price, AcquiredType type) {
+		return AcquiredPencil.create(seller, "", sharedNoteId, price, false, type);
 	}
 
 	private UsedPencil createUsedPencil(Member member, Long sharedNoteId, SharedNote sharedNote,
@@ -142,6 +138,7 @@ public class SharedNoteCommandService {
 		PencilAccount pencilAccount = pencilAccountFinder.findByMemberWithLock(member);
 		pencilAccount.increaseAcquiredBalance(rewardPencilCount);
 		acquiredPencilUpdater.save(
-			createNoteSharedAcquiredPencil(sharedNote.getSharedNoteId(), member, rewardPencilCount.longValue()));
+			createAcquiredPencil(sharedNote.getSharedNoteId(), member, rewardPencilCount.longValue(),
+				AcquiredType.NOTE));
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
@@ -10,6 +10,7 @@ import com.google.cloud.vision.v1.Likelihood;
 import jakarta.persistence.PessimisticLockException;
 import lombok.RequiredArgsConstructor;
 import umc.th.juinjang.api.limjang.service.NoteFinder;
+import umc.th.juinjang.api.limjang.service.NoteUpdater;
 import umc.th.juinjang.api.note.shared.controller.request.SharedNotePostRequest;
 import umc.th.juinjang.api.pencil.service.AcquiredPencilUpdater;
 import umc.th.juinjang.api.pencil.service.UsedPencilFinder;
@@ -39,6 +40,7 @@ public class SharedNoteCommandService {
 	private final NoteFinder noteFinder;
 	private final SharedNoteUpdater sharedNoteUpdater;
 	private final SafeSearchClient safeSearchClient;
+	private final NoteUpdater noteUpdater;
 
 	@Transactional
 	public void createSharedNotePurchase(Member buyer, Long sharedNoteId) {
@@ -94,6 +96,7 @@ public class SharedNoteCommandService {
 
 	@Transactional
 	public void createSharedNote(Member member, Long noteId, SharedNotePostRequest request) {
+		Integer rewardPencilCount = 0;
 		//이미 공유된 임장인지 확인
 		if (sharedNoteFinder.existsByLimjangId(noteId)) {
 			throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_ALREADY_EXISTS);
@@ -102,23 +105,35 @@ public class SharedNoteCommandService {
 		//Limjang 조회
 		Limjang limjang = noteFinder.getNoteByIdWhereDeletedIsFalse(noteId);
 
-		//SafeSearch 검사 (유해 이미지가 하나라도 있으면 차단)
-		for (var image : limjang.getImageList()) {
-			boolean safe = safeSearchClient.isSafeImage(
-				image.getImageUrl(),
-				Likelihood.VERY_LIKELY,  // adult
-				Likelihood.VERY_LIKELY,  // spoof
-				Likelihood.VERY_LIKELY,  // medical
-				Likelihood.VERY_LIKELY,  // violence
-				Likelihood.VERY_LIKELY   // racy
-			);
-			if (!safe) {
-				throw new SharedNoteHandler(ErrorStatus.SHARED_NOT_ALLOWED);
+		//사진 공유 체크 + 임장노트에 사진이 있으면
+		if (request.isImageShared() == Boolean.TRUE && !limjang.getImageList().isEmpty()) {
+			//SafeSearch 검사 (유해 이미지가 하나라도 있으면 차단)
+			for (var image : limjang.getImageList()) {
+				boolean safe = safeSearchClient.isSafeImage(
+					image.getImageUrl(),
+					Likelihood.VERY_LIKELY,  // adult
+					Likelihood.VERY_LIKELY,  // spoof
+					Likelihood.VERY_LIKELY,  // medical
+					Likelihood.VERY_LIKELY,  // violence
+					Likelihood.VERY_LIKELY   // racy
+				);
+				if (!safe) {
+					throw new SharedNoteHandler(ErrorStatus.SHARED_NOT_ALLOWED);
+				}
 			}
+			rewardPencilCount = 7;
 		}
+		//사진 공유 안함 체크 or 임장노트에 사진이 없으면
+		else if (request.isImageShared() == Boolean.TRUE || limjang.getImageList().isEmpty()) {
+			rewardPencilCount = 2;
+		}
+		limjang.updateRewardPencil(rewardPencilCount);
+		noteUpdater.save(limjang);
 
 		//저장
 		SharedNote sharedNote = SharedNote.toSharedNote(member, limjang, request);
 		sharedNoteUpdater.save(sharedNote);
+
+		//사용자 지갑에 rewardPencil만큼 업데이트
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteFinder.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteFinder.java
@@ -34,4 +34,7 @@ public class SharedNoteFinder {
 		return sharedNoteRepository.getLikeCountById(id);
 	}
 
+	public boolean existsByLimjangId(Long limjangId) {
+		return sharedNoteRepository.existsByLimjang_LimjangId(limjangId);
+	}
 }

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteFinder.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteFinder.java
@@ -34,7 +34,7 @@ public class SharedNoteFinder {
 		return sharedNoteRepository.getLikeCountById(id);
 	}
 
-	public boolean existsByLimjangId(Long limjangId) {
-		return sharedNoteRepository.existsByLimjang_LimjangId(limjangId);
+	public Optional<SharedNote> findLatestByLimjangId(Long limjangId) {
+		return sharedNoteRepository.findLatestByLimjangId(limjangId);
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteUpdater.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteUpdater.java
@@ -3,6 +3,7 @@ package umc.th.juinjang.api.note.shared.service;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.domain.note.shared.model.SharedNote;
 import umc.th.juinjang.domain.note.shared.repository.SharedNoteRepository;
 
 @Component
@@ -21,5 +22,9 @@ public class SharedNoteUpdater {
 
 	public void decrementLikedCountById(Long sharedNoteId) {
 		sharedNoteRepository.decrementLikedCountById(sharedNoteId);
+	}
+
+	public SharedNote save(SharedNote sharedNote) {
+		return sharedNoteRepository.save(sharedNote);
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/pencilAccount/service/PencilAccountUpdater.java
+++ b/src/main/java/umc/th/juinjang/api/pencilAccount/service/PencilAccountUpdater.java
@@ -1,0 +1,21 @@
+package umc.th.juinjang.api.pencilAccount.service;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import umc.th.juinjang.domain.pencilaccount.model.PencilAccount;
+import umc.th.juinjang.domain.pencilaccount.repository.PencilAccountRepository;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PencilAccountUpdater {
+
+	private final PencilAccountRepository pencilAccountRepository;
+
+	public void save(PencilAccount pencilAccount) {
+		pencilAccountRepository.save(pencilAccount);
+	}
+
+}

--- a/src/main/java/umc/th/juinjang/common/code/status/ErrorStatus.java
+++ b/src/main/java/umc/th/juinjang/common/code/status/ErrorStatus.java
@@ -108,6 +108,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	SHAREDNOTE_NOT_ENOUGH_PENCIL(HttpStatus.BAD_REQUEST, "SHAREDNOTE4001", "보유한 연필 수가 부족합니다."),
 	SHAREDNOTE_CONFLICT(HttpStatus.CONFLICT, "SHAREDNOTE4002", "이미 구매한 노트입니다."),
 	SHAREDNOTE_DEADLOCK(HttpStatus.LOCKED, "SHAREDNOTE4003", "잠시 후 다시 시도해주세요. 현재 다른 요청이 처리 중입니다."),
+	SHAREDNOTE_ALREADY_EXISTS(HttpStatus.CONFLICT, "SHAREDNOTE4004", "이미 공유된 노트입니다."),
 
 	// LikedNote
 	LIKEDNOTE_CONFLICT(HttpStatus.CONFLICT, "LIKEDNOTE4000", "이미 좋아요한 노트입니다"),

--- a/src/main/java/umc/th/juinjang/common/code/status/ErrorStatus.java
+++ b/src/main/java/umc/th/juinjang/common/code/status/ErrorStatus.java
@@ -110,6 +110,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	SHAREDNOTE_DEADLOCK(HttpStatus.LOCKED, "SHAREDNOTE4003", "잠시 후 다시 시도해주세요. 현재 다른 요청이 처리 중입니다."),
 	SHAREDNOTE_ALREADY_EXISTS(HttpStatus.CONFLICT, "SHAREDNOTE4004", "이미 공유된 노트입니다."),
 	SHARED_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "SAHREDNOTE4005", "공유가 금지된 노트입니다."),
+	SHAREDNOTE_DELETED_RECENTLY(HttpStatus.BAD_REQUEST, "SHAREDNOTE4006", "삭제한지 6개월이 지나지 않아 다시 공유할 수 없습니다."),
 
 	// LikedNote
 	LIKEDNOTE_CONFLICT(HttpStatus.CONFLICT, "LIKEDNOTE4000", "이미 좋아요한 노트입니다"),

--- a/src/main/java/umc/th/juinjang/common/code/status/ErrorStatus.java
+++ b/src/main/java/umc/th/juinjang/common/code/status/ErrorStatus.java
@@ -109,6 +109,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	SHAREDNOTE_CONFLICT(HttpStatus.CONFLICT, "SHAREDNOTE4002", "이미 구매한 노트입니다."),
 	SHAREDNOTE_DEADLOCK(HttpStatus.LOCKED, "SHAREDNOTE4003", "잠시 후 다시 시도해주세요. 현재 다른 요청이 처리 중입니다."),
 	SHAREDNOTE_ALREADY_EXISTS(HttpStatus.CONFLICT, "SHAREDNOTE4004", "이미 공유된 노트입니다."),
+	SHARED_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "SAHREDNOTE4005", "공유가 금지된 노트입니다."),
 
 	// LikedNote
 	LIKEDNOTE_CONFLICT(HttpStatus.CONFLICT, "LIKEDNOTE4000", "이미 좋아요한 노트입니다"),

--- a/src/main/java/umc/th/juinjang/domain/limjang/model/Limjang.java
+++ b/src/main/java/umc/th/juinjang/domain/limjang/model/Limjang.java
@@ -137,6 +137,10 @@ public class Limjang extends BaseEntity {
 		return this.imageList.isEmpty() ? null : this.imageList.get(0).getImageUrl();
 	}
 
+	public void updateRewardPencil(Integer rewardPencil) {
+		this.rewardPencil = rewardPencil;
+	}
+
 	@Builder
 	private Limjang(Member member, LimjangPrice limjangPrice, LimjangPurpose purpose,
 		LimjangPropertyType propertyType, LimjangPriceType priceType,

--- a/src/main/java/umc/th/juinjang/domain/note/shared/model/SharedNote.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/model/SharedNote.java
@@ -1,27 +1,31 @@
 package umc.th.juinjang.domain.note.shared.model;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.FetchType;
-
 import java.sql.Timestamp;
 
 import org.hibernate.annotations.Comment;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.th.juinjang.api.note.shared.controller.request.SharedNotePostRequest;
 import umc.th.juinjang.domain.common.BaseEntity;
 import umc.th.juinjang.domain.limjang.model.Limjang;
 import umc.th.juinjang.domain.member.model.Member;
 
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Entity
 public class SharedNote extends BaseEntity {
 
@@ -65,6 +69,20 @@ public class SharedNote extends BaseEntity {
 
 	public Long increaseLikedCount() {
 		return this.likeCount = (likeCount == null ? 1L : likeCount + 1);
+	}
+
+	public static SharedNote toSharedNote(Member member, Limjang limjang, SharedNotePostRequest dto) {
+		return SharedNote.builder()
+			.member(member)
+			.limjang(limjang)
+			.buildingName(dto.buildingName())
+			.review(dto.review())
+			.year(dto.year())
+			.month(dto.month())
+			.period(dto.period())
+			.price(dto.price())
+			.isImageShared(!limjang.getImageList().isEmpty())
+			.build();
 	}
 }
 

--- a/src/main/java/umc/th/juinjang/domain/note/shared/model/SharedNote.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/model/SharedNote.java
@@ -43,11 +43,11 @@ public class SharedNote extends BaseEntity {
 
 	@Comment("임장시기 연도")
 	@Column(name = "note_year")
-	private int year;
+	private Integer year;
 
 	@Comment("임장시기 월")
 	@Column(name = "note_month")
-	private int month;
+	private Integer month;
 
 	// TODO : 임장시기 - 시기 추후에, ENUM 으로 변경 필요
 	private String period;

--- a/src/main/java/umc/th/juinjang/domain/note/shared/model/SharedNote.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/model/SharedNote.java
@@ -81,7 +81,7 @@ public class SharedNote extends BaseEntity {
 			.month(dto.month())
 			.period(dto.period())
 			.price(dto.price())
-			.isImageShared(!limjang.getImageList().isEmpty())
+			.isImageShared(dto.isImageShared())
 			.build();
 	}
 }

--- a/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteRepository.java
@@ -29,5 +29,6 @@ public interface SharedNoteRepository extends JpaRepository<SharedNote, Long> {
 	@Query("UPDATE SharedNote sn SET sn.likeCount = sn.likeCount - 1 WHERE sn.sharedNoteId = :sharedNoteId")
 	void decrementLikedCountById(@Param("sharedNoteId") Long sharedNoteId);
 
-	boolean existsByLimjang_LimjangId(Long limjangId);
+	@Query("SELECT sn FROM SharedNote sn WHERE sn.limjang.limjangId = :limjangId ORDER BY sn.createdAt DESC")
+	Optional<SharedNote> findLatestByLimjangId(@Param("limjangId") Long limjangId);
 }

--- a/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteRepository.java
@@ -28,4 +28,6 @@ public interface SharedNoteRepository extends JpaRepository<SharedNote, Long> {
 	@Modifying
 	@Query("UPDATE SharedNote sn SET sn.likeCount = sn.likeCount - 1 WHERE sn.sharedNoteId = :sharedNoteId")
 	void decrementLikedCountById(@Param("sharedNoteId") Long sharedNoteId);
+
+	boolean existsByLimjang_LimjangId(Long limjangId);
 }

--- a/src/main/java/umc/th/juinjang/safeSearch/SafeSearchClient.java
+++ b/src/main/java/umc/th/juinjang/safeSearch/SafeSearchClient.java
@@ -17,7 +17,9 @@ import com.google.cloud.vision.v1.Likelihood;
 import com.google.cloud.vision.v1.SafeSearchAnnotation;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class SafeSearchClient {
@@ -47,6 +49,12 @@ public class SafeSearchClient {
 			}
 
 			SafeSearchAnnotation annotation = res.getSafeSearchAnnotation();
+			log.info("SafeSearch 분석 결과 for [{}]", imageUrl);
+			log.info(" - adult: {}", annotation.getAdult());
+			log.info(" - spoof: {}", annotation.getSpoof());
+			log.info(" - medical: {}", annotation.getMedical());
+			log.info(" - violence: {}", annotation.getViolence());
+			log.info(" - racy: {}", annotation.getRacy());
 			return isAnnotationSafe(annotation, adultThreshold, spoofThreshold, medicalThreshold, violenceThreshold,
 				racyThreshold);
 

--- a/src/main/java/umc/th/juinjang/safeSearch/SafeSearchClient.java
+++ b/src/main/java/umc/th/juinjang/safeSearch/SafeSearchClient.java
@@ -1,0 +1,70 @@
+package umc.th.juinjang.safeSearch;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.springframework.stereotype.Component;
+
+import com.google.cloud.vision.v1.AnnotateImageRequest;
+import com.google.cloud.vision.v1.AnnotateImageResponse;
+import com.google.cloud.vision.v1.BatchAnnotateImagesResponse;
+import com.google.cloud.vision.v1.Feature;
+import com.google.cloud.vision.v1.Feature.Type;
+import com.google.cloud.vision.v1.Image;
+import com.google.cloud.vision.v1.ImageAnnotatorClient;
+import com.google.cloud.vision.v1.ImageSource;
+import com.google.cloud.vision.v1.Likelihood;
+import com.google.cloud.vision.v1.SafeSearchAnnotation;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SafeSearchClient {
+
+	public boolean isSafeImage(String imageUrl,
+		Likelihood adultThreshold,
+		Likelihood spoofThreshold,
+		Likelihood medicalThreshold,
+		Likelihood violenceThreshold,
+		Likelihood racyThreshold) {
+		try (ImageAnnotatorClient vision = ImageAnnotatorClient.create()) {
+
+			ImageSource imgSource = ImageSource.newBuilder().setImageUri(imageUrl).build();
+			Image img = Image.newBuilder().setSource(imgSource).build();
+
+			Feature feature = Feature.newBuilder().setType(Type.SAFE_SEARCH_DETECTION).build();
+			AnnotateImageRequest request = AnnotateImageRequest.newBuilder()
+				.addFeatures(feature)
+				.setImage(img)
+				.build();
+
+			BatchAnnotateImagesResponse response = vision.batchAnnotateImages(Collections.singletonList(request));
+			AnnotateImageResponse res = response.getResponsesList().get(0);
+
+			if (res.hasError()) {
+				throw new RuntimeException("Vision API Error: " + res.getError().getMessage());
+			}
+
+			SafeSearchAnnotation annotation = res.getSafeSearchAnnotation();
+			return isAnnotationSafe(annotation, adultThreshold, spoofThreshold, medicalThreshold, violenceThreshold,
+				racyThreshold);
+
+		} catch (IOException e) {
+			throw new RuntimeException("Vision API 호출 실패", e);
+		}
+	}
+
+	public boolean isAnnotationSafe(SafeSearchAnnotation annotation,
+		Likelihood adultThreshold,
+		Likelihood spoofThreshold,
+		Likelihood medicalThreshold,
+		Likelihood violenceThreshold,
+		Likelihood racyThreshold) {
+		return annotation.getAdult().compareTo(adultThreshold) < 0 &&
+			annotation.getSpoof().compareTo(spoofThreshold) < 0 &&
+			annotation.getMedical().compareTo(medicalThreshold) < 0 &&
+			annotation.getViolence().compareTo(violenceThreshold) < 0 &&
+			annotation.getRacy().compareTo(racyThreshold) < 0;
+	}
+}


### PR DESCRIPTION
PM측 컨펌 후 머지 요청 따로 드리겠습니다.
## 작업내용
- 이미 공유된 노트인지 검증
- safe search 검증
- 공유 노트 저장하기

## 상세설명_ & 캡쳐

![ufc](https://github.com/user-attachments/assets/3ad1e61c-d7ba-4efa-bfec-d9e35567d199)
저희 공유 불가능 조건에 충족하는 사진을 찾을 수 없는 관계로 위와 비슷한 결의 사진들로 체크하고
레벨을 테스트 단계에서만 자체적으로 possible로 낮추어 테스트하였습니다.
![image](https://github.com/user-attachments/assets/8d91f1ce-8cb8-4de8-9bcc-13cdd77d091a)
보시면 spoof 부분만 possible로 뜨고 이로 인하여,
![image](https://github.com/user-attachments/assets/a4da401c-67dd-4e50-9042-2205077709c3)
공유가 금지되어 있다고 뜨는 것을 확인할 수 있습니다.

![image](https://github.com/user-attachments/assets/bcb31219-6897-4548-9aa0-31f889af4e76)
이미 공유된 노트가 있을 경우를 테스트한 결과입니다.

