### PR TITLE
[fix/#357] 구매 연필 사용 시 PurchasedPencil에도 반영되도록 fix

### DIFF
--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
@@ -81,7 +81,7 @@ public class SharedNoteCommandService {
 	}
 
 	private void consumePurchasedPencils(Member buyer, long unpaidPencil) {
-		List<PurchasedPencil> purchasedPencils = purchasedPencilUpdater.findByMemberAndRemainQuantityGreaterThanOrderByCreatedAtAsc(
+		List<PurchasedPencil> purchasedPencils = purchasedPencilUpdater.findByMemberAndDeliverySuccessRemainQuantityGreaterThanOrderByCreatedAtAsc(
 			buyer, 0L);
 
 		long remainingToConsume = unpaidPencil;

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
@@ -1,5 +1,7 @@
 package umc.th.juinjang.api.note.shared.service;
 
+import java.util.List;
+
 import org.hibernate.exception.LockAcquisitionException;
 import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.stereotype.Service;
@@ -8,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import jakarta.persistence.PessimisticLockException;
 import lombok.RequiredArgsConstructor;
 import umc.th.juinjang.api.pencil.service.AcquiredPencilUpdater;
+import umc.th.juinjang.api.pencil.service.PurchasedPencilUpdater;
 import umc.th.juinjang.api.pencil.service.UsedPencilFinder;
 import umc.th.juinjang.api.pencil.service.UsedPencilUpdater;
 import umc.th.juinjang.api.pencilAccount.service.PencilAccountFinder;
@@ -17,6 +20,7 @@ import umc.th.juinjang.domain.member.model.Member;
 import umc.th.juinjang.domain.note.shared.model.SharedNote;
 import umc.th.juinjang.domain.pencil.acquired.model.AcquiredPencil;
 import umc.th.juinjang.domain.pencil.acquired.model.AcquiredType;
+import umc.th.juinjang.domain.pencil.purchased.model.PurchasedPencil;
 import umc.th.juinjang.domain.pencil.used.model.UsedPencil;
 import umc.th.juinjang.domain.pencil.used.model.Usedtype;
 import umc.th.juinjang.domain.pencilaccount.model.PencilAccount;
@@ -30,6 +34,7 @@ public class SharedNoteCommandService {
 	private final UsedPencilFinder usedPencilFinder;
 	private final AcquiredPencilUpdater acquiredPencilUpdater;
 	private final PencilAccountFinder pencilAccountFinder;
+	private final PurchasedPencilUpdater purchasedPencilUpdater;
 
 	@Transactional
 	public void createSharedNotePurchase(Member buyer, Long sharedNoteId) {
@@ -43,10 +48,11 @@ public class SharedNoteCommandService {
 			PencilAccount buyerAccount = pencilAccountFinder.findByMemberWithLock(buyer);
 			PencilAccount sellerAccount = pencilAccountFinder.findByMemberWithLock(seller);
 
-			executePayment(buyerAccount, sellerAccount, price);
+			executePayment(buyer, buyerAccount, sellerAccount, price);
 
 			usedPencilUpdater.save(createUsedPencil(buyer, sharedNoteId, sharedNote, buyerAccount));
 			acquiredPencilUpdater.save(createAcquiredPencil(sharedNoteId, seller, price));
+
 		} catch (CannotAcquireLockException | PessimisticLockException | LockAcquisitionException e) {
 			throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_DEADLOCK);
 		}
@@ -58,7 +64,7 @@ public class SharedNoteCommandService {
 		}
 	}
 
-	public void executePayment(PencilAccount buyerAccount, PencilAccount sellerAccount, Long price) {
+	public void executePayment(Member buyer, PencilAccount buyerAccount, PencilAccount sellerAccount, Long price) {
 		long acquiredUsed = Math.min(buyerAccount.getAcquiredBalance(), price);
 		buyerAccount.decreaseAcquiredBalance(acquiredUsed);
 
@@ -67,10 +73,33 @@ public class SharedNoteCommandService {
 			if (buyerAccount.getPurchasedBalance() < unpaidPencil) {
 				throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_NOT_ENOUGH_PENCIL);
 			}
+			consumePurchasedPencils(buyer, unpaidPencil);
 			buyerAccount.decreasePurchasedBalance(unpaidPencil);
 		}
 
 		sellerAccount.increaseAcquiredBalance(price);
+	}
+
+	private void consumePurchasedPencils(Member buyer, long unpaidPencil) {
+		List<PurchasedPencil> purchasedPencils = purchasedPencilUpdater.findByMemberAndRemainQuantityGreaterThanOrderByCreatedAtAsc(
+			buyer, 0L);
+
+		long remainingToConsume = unpaidPencil;
+
+		for (PurchasedPencil purchasedPencil : purchasedPencils) {
+			if (remainingToConsume == 0)
+				break;
+
+			long available = purchasedPencil.getRemainQuantity();
+			long toConsume = Math.min(available, remainingToConsume);
+
+			purchasedPencil.decreaseRemainQuantity(toConsume); // remainQuantity -= toConsume
+			remainingToConsume -= toConsume;
+		}
+
+		if (remainingToConsume > 0) {
+			throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_NOT_ENOUGH_PENCIL);
+		}
 	}
 
 	private AcquiredPencil createAcquiredPencil(Long sharedNoteId, Member seller, Long price) {

--- a/src/main/java/umc/th/juinjang/api/pencil/service/PurchasedPencilUpdater.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/service/PurchasedPencilUpdater.java
@@ -1,0 +1,23 @@
+package umc.th.juinjang.api.pencil.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.domain.member.model.Member;
+import umc.th.juinjang.domain.pencil.purchased.model.PurchasedPencil;
+import umc.th.juinjang.domain.pencil.purchased.repository.PurchasedPencilRepository;
+
+@Component
+@RequiredArgsConstructor
+public class PurchasedPencilUpdater {
+
+	private PurchasedPencilRepository purchasedPencilRepository;
+
+	public List<PurchasedPencil> findByMemberAndRemainQuantityGreaterThanOrderByCreatedAtAsc(Member buyer,
+		Long remainQuantity) {
+		return purchasedPencilRepository.findByMemberAndRemainQuantityGreaterThanOrderByCreatedAtAsc(buyer,
+			remainQuantity);
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/pencil/service/PurchasedPencilUpdater.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/service/PurchasedPencilUpdater.java
@@ -15,9 +15,11 @@ public class PurchasedPencilUpdater {
 
 	private PurchasedPencilRepository purchasedPencilRepository;
 
-	public List<PurchasedPencil> findByMemberAndRemainQuantityGreaterThanOrderByCreatedAtAsc(Member buyer,
+	public List<PurchasedPencil> findByMemberAndDeliverySuccessRemainQuantityGreaterThanOrderByCreatedAtAsc(
+		Member buyer,
 		Long remainQuantity) {
-		return purchasedPencilRepository.findByMemberAndRemainQuantityGreaterThanOrderByCreatedAtAsc(buyer,
+		return purchasedPencilRepository.findByMemberAndDeliverySuccessAndRemainQuantityGreaterThanOrderByCreatedAtAsc(
+			buyer,
 			remainQuantity);
 	}
 }

--- a/src/main/java/umc/th/juinjang/domain/pencil/purchased/model/PurchasedPencil.java
+++ b/src/main/java/umc/th/juinjang/domain/pencil/purchased/model/PurchasedPencil.java
@@ -95,5 +95,9 @@ public class PurchasedPencil extends BaseEntity {
 			.createdAt(createdAt)
 			.build();
 	}
+	
+	public void decreaseRemainQuantity(long quantity) {
+		this.remainQuantity -= quantity;
+	}
 }
 

--- a/src/main/java/umc/th/juinjang/domain/pencil/purchased/repository/PurchasedPencilRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/pencil/purchased/repository/PurchasedPencilRepository.java
@@ -14,7 +14,8 @@ public interface PurchasedPencilRepository extends JpaRepository<PurchasedPencil
 	@Query("SELECT p FROM PurchasedPencil p WHERE p.member = :member AND p.deliveryStatus = 0 ORDER BY p.createdAt DESC")
 	List<PurchasedPencil> findAllByMemberWhereDeliverySuccessOrderByCreatedAtDesc(@Param("member") Member member);
 
-	@Query("select p from PurchasedPencil p where p.member = :member and p.remainQuantity > :remainQuantity order by p.createdAt asc")
-	List<PurchasedPencil> findByMemberAndRemainQuantityGreaterThanOrderByCreatedAtAsc(@Param("member") Member buyer,
+	@Query("select p from PurchasedPencil p where p.member = :member and p.remainQuantity > :remainQuantity AND p.deliveryStatus = 0 order by p.createdAt asc")
+	List<PurchasedPencil> findByMemberAndDeliverySuccessAndRemainQuantityGreaterThanOrderByCreatedAtAsc(
+		@Param("member") Member buyer,
 		@Param("remainQuantity") Long remainQuantity);
 }

--- a/src/main/java/umc/th/juinjang/domain/pencil/purchased/repository/PurchasedPencilRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/pencil/purchased/repository/PurchasedPencilRepository.java
@@ -13,4 +13,8 @@ public interface PurchasedPencilRepository extends JpaRepository<PurchasedPencil
 
 	@Query("SELECT p FROM PurchasedPencil p WHERE p.member = :member AND p.deliveryStatus = 0 ORDER BY p.createdAt DESC")
 	List<PurchasedPencil> findAllByMemberWhereDeliverySuccessOrderByCreatedAtDesc(@Param("member") Member member);
+
+	@Query("select p from PurchasedPencil p where p.member = :member and p.remainQuantity > :remainQuantity order by p.createdAt asc")
+	List<PurchasedPencil> findByMemberAndRemainQuantityGreaterThanOrderByCreatedAtAsc(@Param("member") Member buyer,
+		@Param("remainQuantity") Long remainQuantity);
 }


### PR DESCRIPTION
## 작업내용

구매 연필 사용 시 PurchasedPencil에도 반영되도록 fix

## 상세설명_ & 캡쳐

- PurchasedPencil에서 member가 일치하고 remainQuantity가 0 초과인 것들을 createdAt 오름차순으로 가져옴

```java
	@Query("select p from PurchasedPencil p where p.member = :member and p.remainQuantity > :remainQuantity order by p.createdAt asc")
	List<PurchasedPencil> findByMemberAndRemainQuantityGreaterThanOrderByCreatedAtAsc(@Param("member") Member buyer,
		@Param("remainQuantity") Long remainQuantity);
```

### 기존 코드에 메소드 추가

-구매 연필 사용 시. **consumePurchasedPencils** 메소드 호출

```java

public void executePayment(Member buyer, PencilAccount buyerAccount, PencilAccount sellerAccount, Long price) {
		long acquiredUsed = Math.min(buyerAccount.getAcquiredBalance(), price);
		buyerAccount.decreaseAcquiredBalance(acquiredUsed);

		long unpaidPencil = price - acquiredUsed;
		if (unpaidPencil > 0) {
			if (buyerAccount.getPurchasedBalance() < unpaidPencil) {
				throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_NOT_ENOUGH_PENCIL);
			}
			**consumePurchasedPencils(buyer, unpaidPencil);**
			buyerAccount.decreasePurchasedBalance(unpaidPencil);
		}

		sellerAccount.increaseAcquiredBalance(price);
	}
```


### 전체메소드
- list 돌려 순차적으로 remainQuantity 차감
``` java
	private void consumePurchasedPencils(Member buyer, long unpaidPencil) {
		List<PurchasedPencil> purchasedPencils = purchasedPencilUpdater.findByMemberAndRemainQuantityGreaterThanOrderByCreatedAtAsc(
			buyer, 0L);

		long remainingToConsume = unpaidPencil;

		for (PurchasedPencil purchasedPencil : purchasedPencils) {
			if (remainingToConsume == 0)
				break;

			long available = purchasedPencil.getRemainQuantity();
			long toConsume = Math.min(available, remainingToConsume);

			purchasedPencil.decreaseRemainQuantity(toConsume); // remainQuantity -= toConsume
			remainingToConsume -= toConsume;
		}

		if (remainingToConsume > 0) {
			throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_NOT_ENOUGH_PENCIL);
		}
	}
```

