### PR TITLE
feat: 얻은 연필 읽음 처리 하는 API 구현 완료

### DIFF
--- a/src/main/java/umc/th/juinjang/api/pencil/controller/PencilController.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/controller/PencilController.java
@@ -4,13 +4,16 @@ import java.util.List;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import umc.th.juinjang.api.dto.ApiResponse;
-import umc.th.juinjang.api.pencil.service.PencilService;
+import umc.th.juinjang.api.pencil.service.PencilCommandService;
+import umc.th.juinjang.api.pencil.service.PencilQueryService;
 import umc.th.juinjang.api.pencil.service.response.AcquiredPencilResponse;
 import umc.th.juinjang.api.pencil.service.response.PurchasedPencilResponse;
 import umc.th.juinjang.api.pencil.service.response.UsedPencilResponse;
@@ -21,25 +24,34 @@ import umc.th.juinjang.domain.member.model.Member;
 @RequiredArgsConstructor
 public class PencilController {
 
-	private final PencilService pencilService;
+	private final PencilQueryService pencilQueryService;
+	private final PencilCommandService pencilCommandService;
 
 	@Operation(summary = "얻은 연필 목록을 불러온다.")
 	@GetMapping("/acquired")
 	public ApiResponse<List<AcquiredPencilResponse>> getAcquiredPencilHistory(@AuthenticationPrincipal Member member) {
-		return ApiResponse.onSuccess(pencilService.getAcquiredPencils(member));
+		return ApiResponse.onSuccess(pencilQueryService.getAcquiredPencils(member));
+	}
+
+	@Operation(summary = "얻은 연필 목록에서 읽음 처리를 진행한다.")
+	@PatchMapping("/acquired/{acquiredPencilId}/read")
+	public ApiResponse<Boolean> markAcquiredPencilAsRead(
+		@PathVariable Long acquiredPencilId,
+		@AuthenticationPrincipal Member member) {
+		return ApiResponse.onSuccess(pencilCommandService.markAcquiredPencilAsRead(acquiredPencilId));
 	}
 
 	@Operation(summary = "구매한 연필 목록을 불러온다")
 	@GetMapping("/purchased")
 	public ApiResponse<List<PurchasedPencilResponse>> getPurchasedPencilHistory(
 		@AuthenticationPrincipal Member member) {
-		return ApiResponse.onSuccess(pencilService.getPurchasedPencils(member));
+		return ApiResponse.onSuccess(pencilQueryService.getPurchasedPencils(member));
 	}
 
 	@Operation(summary = "사용한 연필 목록을 불러온다")
 	@GetMapping("/used")
 	public ApiResponse<List<UsedPencilResponse>> getUsedPencilHistory(
 		@AuthenticationPrincipal Member member) {
-		return ApiResponse.onSuccess(pencilService.getUsedPencils(member));
+		return ApiResponse.onSuccess(pencilQueryService.getUsedPencils(member));
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/pencil/service/PencilCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/service/PencilCommandService.java
@@ -1,0 +1,27 @@
+package umc.th.juinjang.api.pencil.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.domain.pencil.acquired.model.AcquiredPencil;
+
+@Service
+@RequiredArgsConstructor
+public class PencilCommandService {
+
+	private final AcquiredPencilFinder acquiredPencilFinder;
+
+	@Transactional
+	public Boolean markAcquiredPencilAsRead(Long acquiredPencilId) {
+		AcquiredPencil acquiredPencil = acquiredPencilFinder.findById(acquiredPencilId);
+
+		if (acquiredPencil == null) {
+			throw new EntityNotFoundException("AcquiredPencil not found with id: " + acquiredPencilId);
+		}
+
+		acquiredPencil.updateIsReadAsTrue();
+		return true;
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/pencil/service/PencilQueryService.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/service/PencilQueryService.java
@@ -15,7 +15,7 @@ import umc.th.juinjang.domain.pencil.used.model.UsedPencil;
 
 @Service
 @RequiredArgsConstructor
-public class PencilService {
+public class PencilQueryService {
 
 	private final AcquiredPencilFinder acquiredPencilFinder;
 	private final PurchasedPencilFinder purchasedPencilFinder;

--- a/src/main/java/umc/th/juinjang/domain/pencil/acquired/model/AcquiredPencil.java
+++ b/src/main/java/umc/th/juinjang/domain/pencil/acquired/model/AcquiredPencil.java
@@ -77,4 +77,8 @@ public class AcquiredPencil extends BaseEntity {
 			.createdAt(createdAt)
 			.build();
 	}
+
+	public void updateIsReadAsTrue() {
+		this.isRead = true;
+	}
 }

--- a/src/test/java/umc/th/juinjang/api/pencil/service/PencilServiceTest.java
+++ b/src/test/java/umc/th/juinjang/api/pencil/service/PencilServiceTest.java
@@ -46,7 +46,7 @@ class PencilServiceTest extends IntegrationTestSupport {
 	private UsedPencilRepository usedPencilRepository;
 
 	@Autowired
-	private PencilService pencilService;
+	private PencilQueryService pencilService;
 
 	@AfterEach
 	void tearDown() {


### PR DESCRIPTION
## 작업내용
- 사용자가 얻은 연필을 클릭했을 때, 
- 읽음 처리를 하는 API 입니다.

## 상세설명_ & 캡쳐

밑과 같이 구현했습니다. 
`
```
 @Transactional
	public Boolean markAcquiredPencilAsRead(Long acquiredPencilId) {
		AcquiredPencil acquiredPencil = acquiredPencilFinder.findById(acquiredPencilId);

		if (acquiredPencil == null) {
			throw new EntityNotFoundException("AcquiredPencil not found with id: " + acquiredPencilId);
		}

		acquiredPencil.updateIsReadAsTrue();
		return true;
	}
```
`

HTTP 로 테스트 해본 경우에 정상적으로 작동했습니다. 
<img width="511" alt="스크린샷 2025-05-06 오후 3 09 08" src="https://github.com/user-attachments/assets/49be623f-aaa8-4744-8491-b1643ba54fce" />
