### PR TITLE
[feat/#366] 조회수 리워드 구현

### DIFF
--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteFinder.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteFinder.java
@@ -1,7 +1,9 @@
 package umc.th.juinjang.api.note.shared.service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -51,5 +53,17 @@ public class SharedNoteFinder {
 	public List<SharedNote> findUserSharedNotes(Member member, NoteType noteType, LimjangPropertyType propertyType,
 		LimjangPriceType priceType, String keyword, List<Long> filterIds) {
 		return sharedNoteRepository.findUserSharedNotes(member, noteType, propertyType, priceType, keyword, filterIds);
+	}
+
+	public Map<Long, Long> findAllIdAndViewCountById(List<Long> ids) {
+		return sharedNoteRepository.findAllViewCountById(ids).stream()
+			.collect(Collectors.toMap(
+				row -> (Long)row[0],
+				row -> (Long)row[1]
+			));
+	}
+
+	public Long findViewCountById(Long id) {
+		return sharedNoteRepository.findViewCountById(id);
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteQueryService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteQueryService.java
@@ -1,24 +1,17 @@
 package umc.th.juinjang.api.note.shared.service;
 
-import java.time.Duration;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.redis.RedisConnectionFailureException;
-import org.springframework.data.redis.RedisSystemException;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.xml.sax.ErrorHandler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,7 +24,6 @@ import umc.th.juinjang.api.pencil.service.UsedPencilFinder;
 import umc.th.juinjang.api.note.shared.service.response.SharedNoteGetResponse;
 import umc.th.juinjang.common.code.status.ErrorStatus;
 import umc.th.juinjang.common.exception.handler.SharedNoteHandler;
-import umc.th.juinjang.common.redis.RedisKeyFactory;
 import umc.th.juinjang.domain.limjang.model.Limjang;
 import umc.th.juinjang.domain.limjang.model.LimjangPriceType;
 import umc.th.juinjang.domain.limjang.model.LimjangPropertyType;
@@ -39,6 +31,7 @@ import umc.th.juinjang.domain.member.model.Member;
 import umc.th.juinjang.domain.note.liked.model.LikedNote;
 import umc.th.juinjang.domain.note.shared.model.SharedNote;
 import umc.th.juinjang.domain.pencil.used.model.UsedPencil;
+import umc.th.juinjang.event.publisher.ApplicationRewardViewCountPublisherAdapter;
 
 @Service
 @Slf4j
@@ -48,7 +41,8 @@ public class SharedNoteQueryService {
 	private final UsedPencilFinder usedPencilFinder;
 	private final SharedNoteFinder sharedNoteFinder;
 	private final LikedNoteFinder likedNoteFinder;
-	private final RedisTemplate<String, String> redisTemplate;
+	private final ViewCountService viewCountService;
+	private final ApplicationRewardViewCountPublisherAdapter applicationRewardViewCountPublisherAdapter;
 
 	@Transactional(readOnly = true)
 	public SharedNoteGetResponse findSharedNote(Member member, Long sharedNoteId) {
@@ -57,12 +51,7 @@ public class SharedNoteQueryService {
 
 		boolean isBuyer = usedPencilFinder.existsByMemberAndSharedNoteId(member, sharedNoteId);
 
-		long viewCount = getTotalViewCount(sharedNote);
-		if (!isDuplicate(member.getMemberId(), sharedNoteId)) {
-			increaseViewCount(sharedNoteId);
-			viewCount++;
-			recordViewerHistory(member.getMemberId(), sharedNoteId);
-		}
+		long viewCount = getViewCountAndCheckReward(member, sharedNoteId, sharedNote);
 
 		Integer countBuyer = makeBuyerCount(usedPencilFinder.countBySharedNoteId(sharedNoteId));
 		boolean isLiked = likedNoteFinder.existsByMemberAndSharedNote(member, sharedNote);
@@ -76,44 +65,17 @@ public class SharedNoteQueryService {
 		}
 	}
 
-	private long getTotalViewCount(SharedNote sharedNote) {
-		return sharedNote.getViewCount() + getRedisViewCount(sharedNote.getSharedNoteId());
-	}
+	private long getViewCountAndCheckReward(Member member, Long sharedNoteId, SharedNote sharedNote) {
+		long viewCount = viewCountService.getRedisViewCount(sharedNote.getSharedNoteId());
+		if (!viewCountService.isDuplicate(member.getMemberId(), sharedNoteId)) {
+			viewCountService.increaseViewCount(sharedNoteId);
+			viewCount++;
+			viewCountService.recordViewerHistory(member.getMemberId(), sharedNoteId);
 
-	private void recordViewerHistory(long memberId, long sharedNoteId) {
-		try {
-			redisTemplate.opsForValue()
-				.setIfAbsent(RedisKeyFactory.viewHistoryKey(sharedNoteId, memberId), "1", Duration.ofHours(3));
-		} catch (RedisConnectionFailureException | RedisSystemException e) {
-			log.error("Redis 연결 실패 - 중복 조회 기록 불가, sharedNoteId={}, memberId={}", sharedNoteId, memberId, e);
+			applicationRewardViewCountPublisherAdapter.checkViewCountRewardPolicy(sharedNote.getMember(),
+				sharedNote.getSharedNoteId(), viewCount);
 		}
-	}
-
-	private void increaseViewCount(long sharedNoteId) {
-		try {
-			redisTemplate.opsForValue().increment(RedisKeyFactory.viewCountKey(sharedNoteId));
-		} catch (RedisConnectionFailureException | RedisSystemException e) {
-			log.error("Redis 조회수 증가 실패, sharedNoteId={}", sharedNoteId, e);
-		}
-	}
-
-	private boolean isDuplicate(long memberId, long sharedNoteId) {
-		try {
-			return Boolean.TRUE.equals(redisTemplate.hasKey(RedisKeyFactory.viewHistoryKey(sharedNoteId, memberId)));
-		} catch (RedisConnectionFailureException | RedisSystemException e) {
-			log.error("Redis 장애로 조회 기록 확인 실패. sharedNoteId={}, memberId={}", sharedNoteId, memberId, e);
-			return false;
-		}
-	}
-
-	private Long getRedisViewCount(long sharedNoteId) {
-		try {
-			Object value = redisTemplate.opsForValue().get(RedisKeyFactory.viewCountKey(sharedNoteId));
-			return value == null ? 0L : Long.parseLong(value.toString());
-		} catch (RedisConnectionFailureException | RedisSystemException e) {
-			log.error("Redis 장애 발생, 기본값 반환 sharedNoteID={}", sharedNoteId, e);
-			return 0L;
-		}
+		return viewCount;
 	}
 
 	private Integer makeBuyerCount(int count) {
@@ -151,7 +113,7 @@ public class SharedNoteQueryService {
 	private Map<Long, Long> mapIdsAndViewcount(List<SharedNote> sharedNotes) {
 		return sharedNotes.stream().collect(Collectors.toMap(
 			SharedNote::getSharedNoteId,
-			this::getTotalViewCount
+			it -> viewCountService.getRedisViewCount(it.getSharedNoteId())
 		));
 	}
 
@@ -214,7 +176,7 @@ public class SharedNoteQueryService {
 		List<LikedNote> userLikedNotes = likedNoteFinder.findAllByMemberAndDynamic(member, propertyType,
 			priceType, keyword);
 		List<SharedNote> sharedNotes = userLikedNotes.stream().map(LikedNote::getSharedNote).toList();
-		
+
 		Set<Long> purchasedIds = new HashSet<>(usedPencilFinder.findByMemberInSharedNoteIdsAndTypeIsOwned(member,
 			sharedNotes.stream().map(SharedNote::getSharedNoteId).toList()));
 		Map<Long, Long> viewcountMap = mapIdsAndViewcount(sharedNotes);

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/ViewCountService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/ViewCountService.java
@@ -1,0 +1,67 @@
+package umc.th.juinjang.api.note.shared.service;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.RedisSystemException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import umc.th.juinjang.common.redis.RedisKeyFactory;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ViewCountService {
+
+	private final RedisTemplate<String, String> redisTemplate;
+	private final SharedNoteFinder sharedNoteFinder;
+
+	public void recordViewerHistory(long memberId, long sharedNoteId) {
+		try {
+			redisTemplate.opsForValue()
+				.setIfAbsent(RedisKeyFactory.viewHistoryKey(sharedNoteId, memberId), "1", Duration.ofHours(3));
+		} catch (RedisConnectionFailureException | RedisSystemException e) {
+			log.error("Redis 연결 실패 - 중복 조회 기록 불가, sharedNoteId={}, memberId={}", sharedNoteId, memberId, e);
+		}
+	}
+
+	public void increaseViewCount(long sharedNoteId) {
+		try {
+			redisTemplate.opsForValue().increment(RedisKeyFactory.viewCountKey(sharedNoteId));
+		} catch (RedisConnectionFailureException | RedisSystemException e) {
+			log.error("Redis 조회수 증가 실패, sharedNoteId={}", sharedNoteId, e);
+		}
+	}
+
+	public boolean isDuplicate(long memberId, long sharedNoteId) {
+		try {
+			return Boolean.TRUE.equals(redisTemplate.hasKey(RedisKeyFactory.viewHistoryKey(sharedNoteId, memberId)));
+		} catch (RedisConnectionFailureException | RedisSystemException e) {
+			log.error("Redis 장애로 조회 기록 확인 실패. sharedNoteId={}, memberId={}", sharedNoteId, memberId, e);
+			return false;
+		}
+	}
+
+	public Long getRedisViewCount(long sharedNoteId) {
+
+		String key = RedisKeyFactory.viewCountKey(sharedNoteId);
+
+		try {
+			Object value = redisTemplate.opsForValue().get(key);
+
+			if (value == null) {
+				Long viewCountFromDb = sharedNoteFinder.findViewCountById(sharedNoteId);
+				redisTemplate.opsForValue().set(key, viewCountFromDb.toString());
+				return viewCountFromDb;
+			}
+
+			return Long.parseLong(value.toString());
+		} catch (RedisConnectionFailureException | RedisSystemException e) {
+			log.error("Redis 장애 발생, 기본값 반환 sharedNoteID={}", sharedNoteId, e);
+			return 0L;
+		}
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/ViewCountSyncScheduler.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/ViewCountSyncScheduler.java
@@ -2,6 +2,9 @@ package umc.th.juinjang.api.note.shared.service;
 
 import static umc.th.juinjang.common.redis.RedisKeyFactory.*;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.springframework.data.redis.core.RedisTemplate;
@@ -19,15 +22,17 @@ public class ViewCountSyncScheduler {
 
 	private final RedisTemplate<String, Object> redisTemplate;
 	private final SharedNoteUpdater sharedNoteUpdater;
+	private final SharedNoteFinder sharedNoteFinder;
 
-	@Scheduled(cron = "0 0 */6 * * *") // 6시간마다 실행
+	@Scheduled(cron = "0 0 */6 * * *")
 	@Transactional
 	public void syncRedisViewCountsToRDB() {
 		Set<String> keys = redisTemplate.keys(VIEW_COUNT + "*");
 		if (keys == null || keys.isEmpty())
 			return;
 
-		log.info("Redis RDB 조회수 동기화 시작: 총 {}개", keys.size());
+		List<Long> sharedNoteIds = getSharedNoteIdsInRedis(keys);
+		Map<Long, Long> dbViewCounts = sharedNoteFinder.findAllIdAndViewCountById(sharedNoteIds);
 
 		for (String key : keys) {
 			try {
@@ -37,13 +42,35 @@ public class ViewCountSyncScheduler {
 					log.warn("조회수 값 없음 - key={}", key);
 					continue;
 				}
-				long addAmount = Long.parseLong(value.toString());
-				sharedNoteUpdater.updateViewCount(sharedNoteId, addAmount);
-				log.info("조회수 동기화: sharedNoteId={}, Redis={}", sharedNoteId, addAmount);
-				redisTemplate.delete(key);
+
+				long redisViewCount = Long.parseLong(value.toString());
+				long dbViewCount = dbViewCounts.getOrDefault(sharedNoteId, 0L);
+
+				if (redisViewCount > dbViewCount) {
+					sharedNoteUpdater.updateViewCount(sharedNoteId, redisViewCount);
+					log.info("조회수 동기화: sharedNoteId={}, Redis={}, DB={}", sharedNoteId, redisViewCount,
+						dbViewCount);
+				} else {
+					log.info("동기화 생략: sharedNoteId={}, Redis={}, DB={}", sharedNoteId, redisViewCount,
+						dbViewCount);
+				}
 			} catch (Exception e) {
 				log.error("동기화 실패: key={}, error={}", key, e.getMessage(), e);
 			}
 		}
+	}
+
+	private List<Long> getSharedNoteIdsInRedis(Set<String> keys) {
+		return keys.stream()
+			.map(k -> {
+				try {
+					return Long.parseLong(k.split(":")[2]);
+				} catch (Exception e) {
+					log.warn("잘못된 키 형식: {}", k);
+					return null;
+				}
+			})
+			.filter(Objects::nonNull)
+			.toList();
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/reward/service/RewardFinder.java
+++ b/src/main/java/umc/th/juinjang/api/reward/service/RewardFinder.java
@@ -1,0 +1,18 @@
+package umc.th.juinjang.api.reward.service;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.domain.reward.model.RewardType;
+import umc.th.juinjang.domain.reward.repository.RewardRepository;
+
+@Component
+@RequiredArgsConstructor
+public class RewardFinder {
+
+	private final RewardRepository rewardRepository;
+
+	boolean existsByTypeAndMilestoneAndSharedNoteId(RewardType type, Long milestone, Long sharedNoteId) {
+		return rewardRepository.existsByTypeAndMilestoneAndSharedNoteId(type, milestone, sharedNoteId);
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/reward/service/RewardService.java
+++ b/src/main/java/umc/th/juinjang/api/reward/service/RewardService.java
@@ -1,0 +1,54 @@
+package umc.th.juinjang.api.reward.service;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.domain.note.shared.model.ViewCountPolicy;
+import umc.th.juinjang.api.pencil.service.AcquiredPencilUpdater;
+import umc.th.juinjang.api.pencilAccount.service.PencilAccountFinder;
+import umc.th.juinjang.domain.member.model.Member;
+import umc.th.juinjang.domain.pencil.acquired.model.AcquiredPencil;
+import umc.th.juinjang.domain.pencil.acquired.model.AcquiredType;
+import umc.th.juinjang.domain.pencilaccount.model.PencilAccount;
+import umc.th.juinjang.domain.reward.model.Reward;
+import umc.th.juinjang.domain.reward.model.RewardType;
+
+@Component
+@RequiredArgsConstructor
+public class RewardService {
+
+	private final AcquiredPencilUpdater acquiredPencilUpdater;
+	private final PencilAccountFinder pencilAccountFinder;
+	private final ViewCountPolicy viewCountPolicy;
+	private final RewardFinder rewardFinder;
+	private final RewardUpdater rewardUpdater;
+
+	@Transactional
+	public void giveViewCountReward(Member member, Long sharedNoteId, Long milestone, Long rewardPencil) {
+
+		if (alreadyViewCountRewardEarned(RewardType.VIEWCOUNT, sharedNoteId, milestone)) {
+			return;
+		}
+
+		PencilAccount account = pencilAccountFinder.findByMemberWithLock(member);
+		account.increaseAcquiredBalance(rewardPencil);
+
+		acquiredPencilUpdater.save(
+			createAcquiredPencil(member, sharedNoteId, milestone, rewardPencil));
+		rewardUpdater.save(createReward(member, sharedNoteId, milestone, rewardPencil));
+	}
+
+	private AcquiredPencil createAcquiredPencil(Member member, Long sharedNoteId, Long milestone, Long rewardPencil) {
+		return AcquiredPencil.create(member, viewCountPolicy.getMessageForMilestone(milestone), sharedNoteId,
+			rewardPencil, false, AcquiredType.VIEWCOUNT);
+	}
+
+	private Reward createReward(Member member, Long sharedNoteId, Long milestone, Long rewardPencil) {
+		return Reward.create(member, RewardType.VIEWCOUNT, milestone, sharedNoteId, rewardPencil);
+	}
+
+	private boolean alreadyViewCountRewardEarned(RewardType type, Long sharedNoteId, Long milestone) {
+		return rewardFinder.existsByTypeAndMilestoneAndSharedNoteId(type, milestone, sharedNoteId);
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/reward/service/RewardUpdater.java
+++ b/src/main/java/umc/th/juinjang/api/reward/service/RewardUpdater.java
@@ -1,0 +1,18 @@
+package umc.th.juinjang.api.reward.service;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.domain.reward.model.Reward;
+import umc.th.juinjang.domain.reward.repository.RewardRepository;
+
+@Component
+@RequiredArgsConstructor
+public class RewardUpdater {
+
+	private final RewardRepository rewardRepository;
+
+	void save(Reward reward) {
+		rewardRepository.save(reward);
+	}
+}

--- a/src/main/java/umc/th/juinjang/domain/note/shared/model/ViewCountPolicy.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/model/ViewCountPolicy.java
@@ -1,0 +1,38 @@
+package umc.th.juinjang.domain.note.shared.model;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ViewCountPolicy {
+
+	private final Map<Long, Long> milestoneRewardMap = Map.of(
+		10L, 1L,
+		25L, 2L,
+		50L, 3L
+	);
+
+	private final Map<Long, String> milestoneMessageMap = Map.of(
+		10L, "조회수 10회 달성!",
+		25L, "조회수 25회 달성!",
+		50L, "조회수 50회 달성!"
+	);
+
+	public Long getRewardForExactMilestone(long viewCount) {
+		return milestoneRewardMap.get(viewCount);
+	}
+
+	public String getMessageForMilestone(long milestone) {
+		String message = milestoneMessageMap.get(milestone);
+		if (message == null) {
+			log.info("정의되지 않은 milestone입니다: milestoen={}", milestone);
+		}
+		return message;
+	}
+}

--- a/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteRepository.java
@@ -1,5 +1,6 @@
 package umc.th.juinjang.domain.note.shared.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,8 +16,8 @@ public interface SharedNoteRepository extends JpaRepository<SharedNote, Long>, S
 	Optional<SharedNote> findByIdWithNoteAndAddress(@Param("sharedNoteId") Long sharedNoteId);
 
 	@Modifying
-	@Query("UPDATE SharedNote s SET s.viewCount = COALESCE(s.viewCount, 0) + :addAmount WHERE s.sharedNoteId = :sharedNoteId")
-	void incrementViewCount(@Param("sharedNoteId") Long sharedNoteId, @Param("addAmount") Long addAmount);
+	@Query("UPDATE SharedNote s SET s.viewCount = :updateViewCount WHERE s.sharedNoteId = :sharedNoteId")
+	void incrementViewCount(@Param("sharedNoteId") Long sharedNoteId, @Param("updateViewCount") Long updateViewCount);
 
 	@Modifying
 	@Query("UPDATE SharedNote sn SET sn.likeCount = sn.likeCount + 1 WHERE sn.sharedNoteId = :sharedNoteId")
@@ -28,4 +29,10 @@ public interface SharedNoteRepository extends JpaRepository<SharedNote, Long>, S
 	@Modifying
 	@Query("UPDATE SharedNote sn SET sn.likeCount = sn.likeCount - 1 WHERE sn.sharedNoteId = :sharedNoteId")
 	void decrementLikedCountById(@Param("sharedNoteId") Long sharedNoteId);
+
+	@Query("SELECT s.sharedNoteId, s.viewCount FROM SharedNote s WHERE s.sharedNoteId IN :ids")
+	List<Object[]> findAllViewCountById(@Param("ids") List<Long> ids);
+
+	@Query("SELECT s.viewCount FROM SharedNote s WHERE s.sharedNoteId = :id")
+	Long findViewCountById(@Param("id") Long id);
 }

--- a/src/main/java/umc/th/juinjang/domain/pencil/acquired/model/AcquiredType.java
+++ b/src/main/java/umc/th/juinjang/domain/pencil/acquired/model/AcquiredType.java
@@ -1,5 +1,5 @@
 package umc.th.juinjang.domain.pencil.acquired.model;
 
 public enum AcquiredType {
-	NOTE, AD, SOLD
+	NOTE, AD, SOLD, VIEWCOUNT
 }

--- a/src/main/java/umc/th/juinjang/domain/reward/model/Reward.java
+++ b/src/main/java/umc/th/juinjang/domain/reward/model/Reward.java
@@ -1,0 +1,63 @@
+package umc.th.juinjang.domain.reward.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.th.juinjang.domain.member.model.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Reward {
+
+	@Id
+	@Column(name = "reward_id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long rewardId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@Enumerated(EnumType.STRING)
+	private RewardType type;
+
+	private Long milestone;
+
+	private Long sharedNoteId;
+
+	private Long rewardPencil;
+
+	@Builder
+	private Reward(Member member, RewardType type, Long milestone, Long sharedNoteId, Long rewardPencil) {
+		this.member = member;
+		this.type = type;
+		this.milestone = milestone;
+		this.sharedNoteId = sharedNoteId;
+		this.rewardPencil = rewardPencil;
+	}
+
+	public static Reward create(Member member, RewardType type, Long milestone, Long sharedNoteId, Long rewardPencil) {
+		return Reward.builder()
+			.member(member)
+			.type(type)
+			.milestone(milestone)
+			.sharedNoteId(sharedNoteId)
+			.rewardPencil(rewardPencil)
+			.build();
+	}
+
+}

--- a/src/main/java/umc/th/juinjang/domain/reward/model/RewardType.java
+++ b/src/main/java/umc/th/juinjang/domain/reward/model/RewardType.java
@@ -1,0 +1,5 @@
+package umc.th.juinjang.domain.reward.model;
+
+public enum RewardType {
+	VIEWCOUNT, AD
+}

--- a/src/main/java/umc/th/juinjang/domain/reward/repository/RewardRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/reward/repository/RewardRepository.java
@@ -1,0 +1,11 @@
+package umc.th.juinjang.domain.reward.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import umc.th.juinjang.domain.reward.model.Reward;
+import umc.th.juinjang.domain.reward.model.RewardType;
+
+public interface RewardRepository extends JpaRepository<Reward, Long> {
+
+	boolean existsByTypeAndMilestoneAndSharedNoteId(RewardType type, Long milestone, Long sharedNoteId);
+}

--- a/src/main/java/umc/th/juinjang/event/RewardViewCountEvent.java
+++ b/src/main/java/umc/th/juinjang/event/RewardViewCountEvent.java
@@ -1,0 +1,13 @@
+package umc.th.juinjang.event;
+
+import umc.th.juinjang.domain.member.model.Member;
+
+public record RewardViewCountEvent(
+	Member member,
+	Long sharedNoteId,
+	Long viewCount
+) {
+	public static RewardViewCountEvent of(Member member, Long sharedNoteId, Long viewCount) {
+		return new RewardViewCountEvent(member, sharedNoteId, viewCount);
+	}
+}

--- a/src/main/java/umc/th/juinjang/event/publisher/ApplicationRewardViewCountPublisherAdapter.java
+++ b/src/main/java/umc/th/juinjang/event/publisher/ApplicationRewardViewCountPublisherAdapter.java
@@ -1,0 +1,20 @@
+package umc.th.juinjang.event.publisher;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.domain.member.model.Member;
+import umc.th.juinjang.event.RewardViewCountEvent;
+
+@RequiredArgsConstructor
+@Component
+public class ApplicationRewardViewCountPublisherAdapter implements RewardViewCountPublisher {
+
+	private final ApplicationEventPublisher applicationEventPublisher;
+
+	@Override
+	public void checkViewCountRewardPolicy(Member member, Long sharedNoteId, Long viewCount) {
+		applicationEventPublisher.publishEvent(RewardViewCountEvent.of(member, sharedNoteId, viewCount));
+	}
+}

--- a/src/main/java/umc/th/juinjang/event/publisher/RewardViewCountPublisher.java
+++ b/src/main/java/umc/th/juinjang/event/publisher/RewardViewCountPublisher.java
@@ -1,0 +1,7 @@
+package umc.th.juinjang.event.publisher;
+
+import umc.th.juinjang.domain.member.model.Member;
+
+public interface RewardViewCountPublisher {
+	void checkViewCountRewardPolicy(Member member, Long sharedNoteId, Long viewCount);
+}

--- a/src/main/java/umc/th/juinjang/event/subscriber/RewardViewCountEventListener.java
+++ b/src/main/java/umc/th/juinjang/event/subscriber/RewardViewCountEventListener.java
@@ -1,0 +1,40 @@
+package umc.th.juinjang.event.subscriber;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import umc.th.juinjang.api.reward.service.RewardService;
+import umc.th.juinjang.domain.note.shared.model.ViewCountPolicy;
+import umc.th.juinjang.event.RewardViewCountEvent;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RewardViewCountEventListener {
+
+	private final ViewCountPolicy viewCountPolicy;
+	private final RewardService rewardService;
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handleRewardViewCountEvent(RewardViewCountEvent rewardViewCountEvent) {
+
+		Long reward = viewCountPolicy.getRewardForExactMilestone(
+			rewardViewCountEvent.viewCount());
+
+		if (reward == null) {
+			return;
+		}
+
+		try {
+			rewardService.giveViewCountReward(rewardViewCountEvent.member(), rewardViewCountEvent.sharedNoteId(),
+				rewardViewCountEvent.viewCount(), reward);
+		} catch (Exception e) {
+			log.error("조회수 리워드 지급 실패", e);
+		}
+	}
+}


### PR DESCRIPTION
## 작업내용

조회수 리워드를 구현했습니다. 

## 상세설명_ & 캡쳐

### ViewCountPolicy

- domain - note - shared - model 패키지 내부에 ViewCountPolicy 객체 생성 

- milestoneRewardMap은 마일스톤(달성 조건) - 보상을 매핑한 Map 형 변수

```java
public class ViewCountPolicy {

	private final Map<Long, Long> milestoneRewardMap = Map.of(
		10L, 1L,
		25L, 2L,
		50L, 3L
	);

	private final Map<Long, String> milestoneMessageMap = Map.of(
		10L, "조회수 10회 달성!",
		25L, "조회수 25회 달성!",
		50L, "조회수 50회 달성!"
	);

	public Long getRewardForExactMilestone(long viewCount) {
		return milestoneRewardMap.get(viewCount);
	}

	public String getMessageForMilestone(long milestone) {
		String message = milestoneMessageMap.get(milestone);
		if (message == null) {
			log.info("정의되지 않은 milestone입니다: milestoen={}", milestone);
		}
		return message;
	}
}
```
### 조회수 카운트 관련 service 분리

- ViewCountService를 생성해서 조회수를 다루는 객체를 분리했습니다.
- 1. 중복 보상인지 확인
- 2, 연필 계좌를 찾고, 계좌 잔액 증가
- 3. 얻은 연필 내역에 데이터 추가
- 4. 보상 내역에 추가 

```java
	@Transactional
	public void giveViewCountReward(Member member, Long sharedNoteId, Long milestone, Long rewardPencil) {

		if (alreadyViewCountRewardEarned(RewardType.VIEWCOUNT, sharedNoteId, milestone)) {
			return;
		}

		PencilAccount account = pencilAccountFinder.findByMemberWithLock(member);
		account.increaseAcquiredBalance(rewardPencil);

		acquiredPencilUpdater.save(
			createAcquiredPencil(member, sharedNoteId, milestone, rewardPencil));
		rewardUpdater.save(createReward(member, sharedNoteId, milestone, rewardPencil));
	}
```


### 이벤트 리스너 구현
- 서비스 간 의존성을 줄이고 최적화를 위해 SharedNoteQueryService에서 이벤트를 발행하여 ViewCountService가 실행되도록 구현하였습니다.
- event.subscriber 패키지 내부
- 리워드 조건이 충족되는지(조회수 조건) 확인하고, 충족시 ViewCountService 호출

```java 
	@Async
	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
	public void handleRewardViewCountEvent(RewardViewCountEvent rewardViewCountEvent) {

		Long reward = viewCountPolicy.getRewardForExactMilestone(
			rewardViewCountEvent.viewCount());

		if (reward == null) {
			return;
		}

		try {
			rewardService.giveViewCountReward(rewardViewCountEvent.member(), rewardViewCountEvent.sharedNoteId(),
				rewardViewCountEvent.viewCount(), reward);
		} catch (Exception e) {
			log.error("조회수 리워드 지급 실패", e);
		}
	}
```

### Reward Entity 생성 및 중복 보상 방지

- Reward 엔티티를 추가해서 중복 보상을 방지하는 로직을 생성했습니다.
- 
```java 
	private boolean alreadyViewCountRewardEarned(RewardType type, Long sharedNoteId, Long milestone) {
		return rewardFinder.existsByTypeAndMilestoneAndSharedNoteId(type, milestone, sharedNoteId);
	}
```
