### PR TITLE
[fix/#371] 공유 중단된 노트 조회하지 않도록 조건문 처리

### DIFF
--- a/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteQueryDSLRepositoryImpl.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteQueryDSLRepositoryImpl.java
@@ -55,7 +55,9 @@ public class SharedNoteQueryDSLRepositoryImpl implements SharedNoteQueryDSLRepos
 				getBcodesStartsWith(code),
 				getWhereByPropertyType(propertyType),
 				getWhereByPriceType(priceType),
-				keywordCondition(keyword))
+				keywordCondition(keyword),
+				sharedNote.deletedAt.isNull()
+			)
 			.orderBy(getOrderBySortOptions(sort))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())

--- a/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteQueryDSLRepositoryImpl.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteQueryDSLRepositoryImpl.java
@@ -73,7 +73,8 @@ public class SharedNoteQueryDSLRepositoryImpl implements SharedNoteQueryDSLRepos
 				getBcodesStartsWith(code),
 				getWhereByPropertyType(propertyType),
 				getWhereByPriceType(priceType),
-				keywordCondition(keyword)
+				keywordCondition(keyword),
+				sharedNote.deletedAt.isNull()
 			);
 		long totalCount = countQuery.fetchOne();
 		return new PageImpl<>(content, pageable, totalCount);


### PR DESCRIPTION
## 작업내용

공유 중단된 노트 조회하지 않도록 조건문 처리

## 상세설명_ & 캡쳐

deleteAt 필드가 null인 sharedNote만 조회하도록 처리하였습니다.