### PR TITLE
[fix/#379] 공유 가능 노트 화면 수정에 따른 API fix

### DIFF
--- a/src/main/java/umc/th/juinjang/api/limjang/service/NoteFinder.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/service/NoteFinder.java
@@ -34,7 +34,7 @@ public class NoteFinder {
 
 	protected List<Limjang> getAllByMemberWithAddressAndNotePriceWhereRewardPencilIsNotNullAndDeletedIsFalse(
 		Member member) {
-		return limjangRepository.findAllByMemberWithAddressAndNotePriceWhereRewardPencilIsNotNullAndDeletedIsFalse(
+		return limjangRepository.findAllByMemberWithAddressAndNotePriceWhereIsSharableIsTrueAndDeletedIsFalse(
 			member);
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/limjang/service/response/UserNotesShareableGetResponse.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/service/response/UserNotesShareableGetResponse.java
@@ -24,8 +24,7 @@ public record UserNotesShareableGetResponse(
 		String monthlyRent,
 		Integer pyong,
 		String floor,
-		String shortAddress,
-		int rewardPencil
+		String shortAddress
 	) {
 
 		static UserNoteShareableResponse of(Limjang limjang, String imageUrl, boolean isScraped) {
@@ -40,8 +39,7 @@ public record UserNotesShareableGetResponse(
 					null,
 				limjang.getPyong(),
 				limjang.getFloor(),
-				limjang.getAddressEntity().getShortAddress(),
-				limjang.getRewardPencil()
+				limjang.getAddressEntity().getShortAddress()
 			);
 		}
 	}

--- a/src/main/java/umc/th/juinjang/domain/limjang/repository/LimjangRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/limjang/repository/LimjangRepository.java
@@ -60,7 +60,7 @@ public interface LimjangRepository extends JpaRepository<Limjang, Long>, Limjang
 	@Query("SELECT l FROM Limjang l join fetch l.addressEntity join fetch l.limjangPrice WHERE l.limjangId = :id AND l.deleted = false")
 	Optional<Limjang> findByIdWithAddressAndNotePriceWhereDeletedIsFalse(@Param("id") Long id);
 
-	@Query("SELECT l FROM Limjang l join fetch l.addressEntity join fetch l.limjangPrice left join fetch l.report WHERE l.memberId = :member AND l.deleted = false AND l.rewardPencil IS NOT null ")
-	List<Limjang> findAllByMemberWithAddressAndNotePriceWhereRewardPencilIsNotNullAndDeletedIsFalse(
+	@Query("SELECT l FROM Limjang l join fetch l.addressEntity join fetch l.limjangPrice left join fetch l.report WHERE l.memberId = :member AND l.deleted = false AND l.isSharable = true")
+	List<Limjang> findAllByMemberWithAddressAndNotePriceWhereIsSharableIsTrueAndDeletedIsFalse(
 		@Param("member") Member member);
 }


### PR DESCRIPTION
## 작업내용

공유 가능 노트 화면 수정에 따른 API fix

## 상세설명_ & 캡쳐

- 기존 response Entity에서 필드 제거
- 쿼리 수정 (is_sharable 필드가 true인 조건문으로 수정)