### PR TITLE
[feat/#327] 연필 구매하기 API 구현 

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -45,9 +45,28 @@ jobs:
           echo "${{ secrets.APPLE_AUTH }}" > ./src/main/resources/AUTHKEY_JUINJAG.p8
         shell: bash
 
+      # APPLE IN_APP 결제 관련 프로세스 시작
+      - name: Create certs directory
+        run: mkdir -p ./src/main/resources/certs
+
+      - name: Create Apple Certificates
+        run: |
+          echo "${{ secrets.APPLE_IAP_CA_G3_CERT }}" | base64 -d > ./src/main/resources/certs/AppleRootCA-G3.cer
+          echo "${{ secrets.APPLE_IAP_CA_G2_CERT }}" | base64 -d > ./src/main/resources/certs/AppleRootCA-G2.cer
+          echo "${{ secrets.APPLE_IAP_ROOT_CERT }}" | base64 -d > ./src/main/resources/certs/AppleIncRootCertificate.cer
+        shell: bash
+
+      - name: Create certs directory
+        run: mkdir -p ./src/main/resources/keys
+
+      - name: Create IAP .p8
+        run: |
+          echo "${{ secrets.APPLE_IAP_KEY }}" > ./src/main/resources/keys/SubscriptionKey_Q5646J7W54.p8
+        shell: bash
+      # APPLE IN_APP 결제 관련 프로세스 끝
+
       - name: Build With Gradle
         run: ./gradlew build -x test
-
 
       - name: Login to Docker Hub
         run: |

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -39,7 +39,7 @@ jobs:
         shell: bash
 
       - name: Run tests
-        run: ./gradlew test --no-daemon --continue
+        run: ./gradlew test --no-daemon --continue --stacktrace --info
 
       - name: Build With Gradle
         run: ./gradlew build -x test

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -32,5 +32,14 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Create application-dev.yml
+        run: |
+          mkdir -p ./src/main/resources
+          echo "${{ secrets.PROPERTIES_DEV }}" > ./src/main/resources/application-dev.yml
+        shell: bash
+
+      - name: Run tests
+        run: ./gradlew test --no-daemon --continue
+
       - name: Build With Gradle
         run: ./gradlew build -x test

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,15 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    testLogging {
+        events("passed", "skipped", "failed")
+        showStandardStreams = false
+    }
 }
+
+
+
+
 
 def generated = 'src/main/generated'
 tasks.withType(JavaCompile).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+
     //
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign' // 4.1.0
 //	implementation 'org.springframework.cloud:spring-cloud-commons:4.1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,8 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // Apple
+    implementation 'com.apple.itunes.storekit:app-store-server-library:3.4.0'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -90,8 +90,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     //Safe Search
-    // Apple
+    implementation 'com.google.cloud:google-cloud-vision:3.58.0'
 
+    // Apple
+    implementation 'com.apple.itunes.storekit:app-store-server-library:3.4.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/umc/th/juinjang/JuinjangApplication.java
+++ b/src/main/java/umc/th/juinjang/JuinjangApplication.java
@@ -4,6 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
@@ -11,6 +12,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableAsync
 @ImportAutoConfiguration({FeignAutoConfiguration.class})
 @EnableScheduling
+@EnableRetry
 public class JuinjangApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/umc/th/juinjang/api/apple/controller/AppleController.java
+++ b/src/main/java/umc/th/juinjang/api/apple/controller/AppleController.java
@@ -1,0 +1,13 @@
+package umc.th.juinjang.api.apple.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v2/apple")
+@RequiredArgsConstructor
+public class AppleController {
+
+}

--- a/src/main/java/umc/th/juinjang/api/apple/service/AppleService.java
+++ b/src/main/java/umc/th/juinjang/api/apple/service/AppleService.java
@@ -2,16 +2,13 @@ package umc.th.juinjang.api.apple.service;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.KeyFactory;
-import java.security.PrivateKey;
-import java.security.spec.PKCS8EncodedKeySpec;
-import java.util.Base64;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 import com.apple.itunes.storekit.client.APIException;
@@ -24,6 +21,8 @@ import com.apple.itunes.storekit.verification.VerificationException;
 
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+import umc.th.juinjang.api.apple.service.command.AppleTransactionVerifyCommand;
+import umc.th.juinjang.api.pencil.service.response.VerificationResult;
 
 @Slf4j
 @Service
@@ -50,7 +49,7 @@ public class AppleService {
 	@Value("${apple.iap.private-key-path}")
 	private String privateKeyPath;
 
-	private  SignedDataVerifier signedDataVerifier;
+	private SignedDataVerifier signedDataVerifier;
 	private AppStoreServerAPIClient appStoreServerAPIClient;
 
 	@PostConstruct
@@ -81,11 +80,92 @@ public class AppleService {
 
 	}
 
+	@Retryable(
+		maxAttempts = 3,
+		backoff = @Backoff(delay = 1000),
+		retryFor = { APIException.class, IOException.class, VerificationException.class })
 	public JWSTransactionDecodedPayload getTransactionInfo(String transactionId) throws APIException, IOException, VerificationException {
+		log.info("Executing GetTransactionInfo for TRANSACTION_ID: {} - Thread: {}",
+			transactionId, Thread.currentThread().getName());
+
 		TransactionInfoResponse transactionInfo = appStoreServerAPIClient.getTransactionInfo(transactionId);
 		return signedDataVerifier.verifyAndDecodeTransaction(transactionInfo.getSignedTransactionInfo());
 	}
 
+	public VerificationResult verifyAppleTransaction(AppleTransactionVerifyCommand command) {
+		try {
+			JWSTransactionDecodedPayload payload = getTransactionInfo(command.getTransactionId());
+
+			if (!validateTransaction(payload, command)) {
+				return VerificationResult.ofVerificationError();
+			}
+
+			return VerificationResult.ofSuccess(payload);
+
+		} catch (IOException | APIException e) {
+			log.warn("❌ Apple transaction verification error. transactionId: {}", command.getTransactionId(), e);
+			return VerificationResult.ofServerError();
+		}catch (VerificationException e) {
+			log.warn("❌ Apple transaction verification error. transactionId: {}", command.getTransactionId(), e);
+			return VerificationResult.ofVerificationError();
+		}
+	}
+
+
+	private boolean validateTransaction(JWSTransactionDecodedPayload decodedPayload, AppleTransactionVerifyCommand command) {
+		// 트랜잭션 아이디가 정상적으로 일치하는 지 여부
+		if (!decodedPayload.getTransactionId().equals(command.getTransactionId())) {
+			log.warn("트랜잭션 아이디 불일치. 애플 PAYLOAD : {}, REQUEST 요청 : {}",decodedPayload.getTransactionId(), command.getTransactionId());
+			return false;
+		}
+
+		// 1. 환불/취소 여부 확인
+		if (decodedPayload.getRevocationDate() != null || decodedPayload.getRevocationReason() != null) {
+			log.warn("트랜잭션이 취소되었습니다. 트랜잭션 ID: {}, 취소 이유: {}",
+				decodedPayload.getTransactionId(), decodedPayload.getRevocationReason());
+			return false;
+		}
+
+		// 2. 번들 ID가 앱의 번들 ID와 일치하는지 검증
+		if (!bundleId.equals(decodedPayload.getBundleId())) {
+			log.warn("번들 ID 불일치. 예상: {}, 실제: {}",
+				bundleId, decodedPayload.getBundleId());
+			return false;
+		}
+
+		// 3. 상품 ID가 요청한 상품과 일치하는지 검증
+		if (!command.getProductId().equals(decodedPayload.getProductId())) {
+			log.warn("상품 ID 불일치. 요청: {}, 응답: {}",
+				command.getProductId(), decodedPayload.getProductId());
+			return false;
+		}
+
+		// 4. 환경 확인 - 프로덕션에서는 프로덕션, 개발에서는 샌드박스인지 확인
+		// boolean isProduction = !"Sandbox".equalsIgnoreCase(decodedPayload.getEnvironment());
+		// if (isProduction) {
+		// 	log.warn("환경 불일치. 프로덕션 여부: {}, 프로덕션이어야 함: {}",
+		// 		isProduction, shouldBeProduction);
+		// 	return false;
+		// }
+
+		// 5. 수량 검증
+		if (decodedPayload.getQuantity() <= 0) {
+			log.warn("유효하지 않은 수량: {}", decodedPayload.getQuantity());
+			return false;
+		}
+
+		// 6. 앱 계정 토큰이 제공된 경우 일치하는지 확인
+		if (command.getAppAccountToken() != null && decodedPayload.getAppAccountToken() != null &&
+			!command.getAppAccountToken().equals(decodedPayload.getAppAccountToken())) {
+			log.warn("앱 계정 토큰 불일치. 요청: {}, 응답: {}",
+				command.getAppAccountToken(), decodedPayload.getAppAccountToken());
+			return false;
+		}
+
+		// 7. 모든 검증이 완료되었으므로 true 반환
+		log.info("Apple IAP Purchase Validation Success. Transaction ID: {}", decodedPayload.getTransactionId());
+		return true;
+	}
 
 	private Set<InputStream> loadRootCertificates() {
 		try {
@@ -115,6 +195,9 @@ public class AppleService {
 			throw new RuntimeException("Failed to load root certificates", e);
 		}
 	}
+
+
+
 
 	private String loadSigningKey() {
 		try {

--- a/src/main/java/umc/th/juinjang/api/apple/service/AppleService.java
+++ b/src/main/java/umc/th/juinjang/api/apple/service/AppleService.java
@@ -1,0 +1,143 @@
+package umc.th.juinjang.api.apple.service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+
+import com.apple.itunes.storekit.client.APIException;
+import com.apple.itunes.storekit.client.AppStoreServerAPIClient;
+import com.apple.itunes.storekit.model.Environment;
+import com.apple.itunes.storekit.model.JWSTransactionDecodedPayload;
+import com.apple.itunes.storekit.model.TransactionInfoResponse;
+import com.apple.itunes.storekit.verification.SignedDataVerifier;
+import com.apple.itunes.storekit.verification.VerificationException;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class AppleService {
+
+	@Value("${apple.iap.bundle-id}")
+	private String bundleId;
+
+	@Value("${apple.iap.key-id}")
+	private String keyId;
+
+	@Value("${apple.iap.issuer-id}")
+	private String issuerId;
+
+	@Value("${apple.iap.apple-id}")
+	private String appleIdStr;
+
+	@Value("${apple.iap.environment}")
+	private String environmentString; // SANDBOX , PRODUCTION
+
+	@Value("${apple.iap.certificate-names}")
+	private String certificateConfigs;
+
+	@Value("${apple.iap.private-key-path}")
+	private String privateKeyPath;
+
+	private  SignedDataVerifier signedDataVerifier;
+	private AppStoreServerAPIClient appStoreServerAPIClient;
+
+	@PostConstruct
+	public void init() {
+		Set<InputStream> rootCertificates = loadRootCertificates();
+
+		Environment environment = Environment.fromValue(environmentString);
+		Long appleId = Long.valueOf(appleIdStr);
+
+		this.signedDataVerifier = new SignedDataVerifier(
+			rootCertificates,
+			bundleId,
+			appleId,
+			environment,
+			true
+		);
+
+
+		String signingKey = loadSigningKey();
+
+		this.appStoreServerAPIClient = new AppStoreServerAPIClient(
+			signingKey,
+			issuerId,
+			keyId,
+			bundleId,
+			environment
+		);
+
+	}
+
+	public JWSTransactionDecodedPayload getTransactionInfo(String transactionId) throws APIException, IOException, VerificationException {
+		TransactionInfoResponse transactionInfo = appStoreServerAPIClient.getTransactionInfo(transactionId);
+		return signedDataVerifier.verifyAndDecodeTransaction(transactionInfo.getSignedTransactionInfo());
+	}
+
+
+	private Set<InputStream> loadRootCertificates() {
+		try {
+			Set<InputStream> certificates = new HashSet<>();
+			String[] certConfigs = certificateConfigs.split(",");
+
+			for (String name : certConfigs) {
+				String certPath = "certs/" + name.trim();
+				ClassPathResource resource = new ClassPathResource(certPath);
+
+				if (resource.exists()) {
+					log.info("Loading certificate: {}", certPath);
+					certificates.add(resource.getInputStream());
+				} else {
+					log.warn("Certificate not found: {}", certPath);
+				}
+			}
+
+			if (certificates.isEmpty()) {
+				log.error("No certificates were loaded");
+				throw new RuntimeException("Failed to load any certificates");
+			}
+
+			return certificates;
+		} catch (Exception e) {
+			log.error("Error loading root certificates: {}", e.getMessage(), e);
+			throw new RuntimeException("Failed to load root certificates", e);
+		}
+	}
+
+	private String loadSigningKey() {
+		try {
+			log.info("Loading signing key from: {}", privateKeyPath);
+
+			ClassPathResource resource = new ClassPathResource(privateKeyPath);
+			String privateKeyContent;
+
+			try (InputStream inputStream = resource.getInputStream()) {
+				privateKeyContent = new String(inputStream.readAllBytes());
+			}
+
+			privateKeyContent = privateKeyContent
+				.replace("-----BEGIN PRIVATE KEY-----", "")
+				.replace("-----END PRIVATE KEY-----", "")
+				.replaceAll("\\s", "");
+
+			log.info("Signing key loaded successfully");
+			return privateKeyContent;
+
+		} catch (Exception e) {
+			log.error("Failed to load signing key: {}", e.getMessage(), e);
+			throw new RuntimeException("Failed to load signing key", e);
+		}
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/apple/service/command/AppleTransactionVerifyCommand.java
+++ b/src/main/java/umc/th/juinjang/api/apple/service/command/AppleTransactionVerifyCommand.java
@@ -1,0 +1,30 @@
+package umc.th.juinjang.api.apple.service.command;
+
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Getter;
+import umc.th.juinjang.api.pencil.controller.request.AppleIAPPurchaseRequest;
+
+@Getter
+public class AppleTransactionVerifyCommand {
+
+	private String transactionId;
+	private String productId;
+	private UUID appAccountToken;
+	private String bundleId;
+
+	@Builder
+	private AppleTransactionVerifyCommand(String transactionId, String productId, UUID appAccountToken, String bundleId) {
+		this.transactionId = transactionId;
+		this.productId = productId;
+		this.appAccountToken = appAccountToken;
+		this.bundleId = bundleId;
+	}
+
+	public static AppleTransactionVerifyCommand fromRequest(AppleIAPPurchaseRequest request){
+		return AppleTransactionVerifyCommand.builder().transactionId(request.getTransactionId())
+			.productId(request.getProductId()).appAccountToken(request.getAppAccountToken()).bundleId(request.getProductId()).build();
+	}
+
+}

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteQueryService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteQueryService.java
@@ -45,7 +45,6 @@ public class SharedNoteQueryService {
 	private final SharedNoteFinder sharedNoteFinder;
 	private final LikedNoteFinder likedNoteFinder;
 	private final ChecklistAnswerFinder checklistAnswerFinder;
-	private final RedisTemplate<String, String> redisTemplate;
 	private final ViewCountService viewCountService;
 	private final ApplicationRewardViewCountPublisherAdapter applicationRewardViewCountPublisherAdapter;
 

--- a/src/main/java/umc/th/juinjang/api/pencil/controller/PencilController.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/controller/PencilController.java
@@ -1,20 +1,25 @@
 package umc.th.juinjang.api.pencil.controller;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import umc.th.juinjang.api.dto.ApiResponse;
+import umc.th.juinjang.api.pencil.controller.request.AppleIAPPurchaseRequest;
 import umc.th.juinjang.api.pencil.service.PencilCommandService;
 import umc.th.juinjang.api.pencil.service.PencilQueryService;
 import umc.th.juinjang.api.pencil.service.response.AcquiredPencilResponse;
+import umc.th.juinjang.api.pencil.service.response.AppleIAPPurchaseResponse;
 import umc.th.juinjang.api.pencil.service.response.PurchasedPencilResponse;
 import umc.th.juinjang.api.pencil.service.response.UsedPencilResponse;
 import umc.th.juinjang.domain.member.model.Member;
@@ -53,5 +58,14 @@ public class PencilController {
 	public ApiResponse<List<UsedPencilResponse>> getUsedPencilHistory(
 		@AuthenticationPrincipal Member member) {
 		return ApiResponse.onSuccess(pencilQueryService.getUsedPencils(member));
+	}
+
+	@Operation(summary = "애플 인앱 결제를 통해 연필을 구매한다")
+	@PostMapping("/purchase/apple")
+	public ApiResponse<AppleIAPPurchaseResponse> purchasePencil(
+		@AuthenticationPrincipal Member member,
+		@RequestBody AppleIAPPurchaseRequest request
+	) {
+		return ApiResponse.onSuccess(pencilCommandService.processAppleIAPPurchase(request , member, LocalDateTime.now()));
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/pencil/controller/request/AppleIAPPurchaseRequest.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/controller/request/AppleIAPPurchaseRequest.java
@@ -1,0 +1,37 @@
+package umc.th.juinjang.api.pencil.controller.request;
+
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AppleIAPPurchaseRequest {
+	private String transactionId;
+	private UUID appAccountToken;
+	private Long pencilQuantity;
+	private Long price;
+	private String productId;
+
+	@Builder
+	private AppleIAPPurchaseRequest(String transactionId, UUID appAccountToken, Long pencilQuantity, Long price,
+		String productId) {
+		this.transactionId = transactionId;
+		this.appAccountToken = appAccountToken;
+		this.pencilQuantity = pencilQuantity;
+		this.price = price;
+		this.productId = productId;
+	}
+
+	public static AppleIAPPurchaseRequest of(String transactionId, UUID appAccountToken, Long pencilQuantity,
+		Long price,
+		String productId) {
+		return AppleIAPPurchaseRequest.builder()
+			.transactionId(transactionId)
+			.appAccountToken(appAccountToken)
+			.pencilQuantity(pencilQuantity)
+			.price(price)
+			.productId(productId)
+			.build();
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/pencil/controller/request/AppleIAPPurchaseRequest.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/controller/request/AppleIAPPurchaseRequest.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import lombok.Builder;
 import lombok.Getter;
+import umc.th.juinjang.domain.pencil.purchased.model.PurchasedPencil;
 
 @Getter
 public class AppleIAPPurchaseRequest {
@@ -12,26 +13,39 @@ public class AppleIAPPurchaseRequest {
 	private Long pencilQuantity;
 	private Long price;
 	private String productId;
+	private Long playTime;
 
 	@Builder
 	private AppleIAPPurchaseRequest(String transactionId, UUID appAccountToken, Long pencilQuantity, Long price,
-		String productId) {
+		String productId , Long playTime) {
 		this.transactionId = transactionId;
 		this.appAccountToken = appAccountToken;
 		this.pencilQuantity = pencilQuantity;
 		this.price = price;
 		this.productId = productId;
+		this.playTime = playTime;
 	}
 
 	public static AppleIAPPurchaseRequest of(String transactionId, UUID appAccountToken, Long pencilQuantity,
-		Long price,
-		String productId) {
+		Long price, String productId, Long playTime) {
 		return AppleIAPPurchaseRequest.builder()
 			.transactionId(transactionId)
 			.appAccountToken(appAccountToken)
 			.pencilQuantity(pencilQuantity)
 			.price(price)
 			.productId(productId)
+			.playTime(playTime)
 			.build();
 	}
+
+	public static AppleIAPPurchaseRequest ofRetry(PurchasedPencil pencil) {
+		return AppleIAPPurchaseRequest.builder()
+			.transactionId(pencil.getTransactionId())
+			.pencilQuantity(pencil.getPurchaseQuantity())
+			.price(pencil.getPrice())
+			.playTime(pencil.getPlayTime())
+			.appAccountToken(pencil.getAppAccountToken())
+			.build();
+	}
+
 }

--- a/src/main/java/umc/th/juinjang/api/pencil/service/PencilCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/service/PencilCommandService.java
@@ -1,17 +1,38 @@
 package umc.th.juinjang.api.pencil.service;
 
+import java.time.LocalDateTime;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.apple.itunes.storekit.model.JWSTransactionDecodedPayload;
+
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import umc.th.juinjang.api.apple.service.AppleService;
+import umc.th.juinjang.api.pencil.controller.request.AppleIAPPurchaseRequest;
+import umc.th.juinjang.api.pencil.service.response.AppleIAPPurchaseResponse;
+import umc.th.juinjang.api.pencilAccount.service.PencilAccountFinder;
+import umc.th.juinjang.domain.member.model.Member;
 import umc.th.juinjang.domain.pencil.acquired.model.AcquiredPencil;
+import umc.th.juinjang.domain.pencil.purchased.model.PurchasedPencil;
+import umc.th.juinjang.domain.pencilaccount.model.PencilAccount;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PencilCommandService {
 
+	private final AppleService appleService;
+
+	private final PurchasedPencilUpdater purchasedPencilUpdater;
 	private final AcquiredPencilFinder acquiredPencilFinder;
+	private final PencilAccountFinder pencilAccountFinder;
+
+	@Value("${apple.iap.bundle-id}")
+	String appleBundleId;
 
 	@Transactional
 	public Boolean markAcquiredPencilAsRead(Long acquiredPencilId) {
@@ -22,6 +43,96 @@ public class PencilCommandService {
 		}
 
 		acquiredPencil.updateIsReadAsTrue();
+		return true;
+	}
+
+	@Transactional
+	public AppleIAPPurchaseResponse processAppleIAPPurchase(AppleIAPPurchaseRequest request, Member member,
+		LocalDateTime now) {
+		String transactionId = request.getTransactionId();
+		Long pencilAmount = request.getPencilQuantity();
+
+		// 트랜잭션이 중복되는 지 체크가 필요한 가?
+		try{
+			// 1. 애플 서버로부터 트랜잭션 정보 가져오기
+			JWSTransactionDecodedPayload decodedPayload = appleService.getTransactionInfo(transactionId);
+
+			// 2. 서버와의 검증 수행
+			if (!validateTransaction(decodedPayload,request)){
+				// PurchasePencil에 결과 저장
+				return null;
+			}
+
+			PencilAccount pencilAccount = pencilAccountFinder.findByMemberWithLock(member);
+			pencilAccount.increasePurchasedBalance(pencilAmount);
+
+			String title = "연필 10개 구매";
+
+			PurchasedPencil purchasedPencil = PurchasedPencil.createSuccessPurchase(
+				member, title, 10L, pencilAmount, transactionId, request.getAppAccountToken(),now);
+
+			purchasedPencilUpdater.save(purchasedPencil);
+
+			log.info("Apple IAP Purchase Success. Transaction ID: {}, Total Balance Amount: {} , Total Purchase Amount: {}",
+				transactionId, pencilAccount.getTotalBalance(), pencilAccount.getTotalPurchaseAmount());
+			return AppleIAPPurchaseResponse.of(transactionId, pencilAccount.getTotalBalance());
+		}catch (Exception e){
+			return null;
+		}
+	}
+
+	private boolean validateTransaction(JWSTransactionDecodedPayload decodedPayload, AppleIAPPurchaseRequest request) {
+		// 트랜잭션 아이디가 정상적으로 일치하는 지 여부
+		if (!decodedPayload.getTransactionId().equals(request.getTransactionId())) {
+			log.warn("트랜잭션 아이디 불일치. 애플 PAYLOAD : {}, REQUEST 요청 : {}",decodedPayload.getTransactionId(), request.getTransactionId());
+			return false;
+		}
+
+		// 1. 환불/취소 여부 확인
+		if (decodedPayload.getRevocationDate() != null || decodedPayload.getRevocationReason() != null) {
+			log.warn("트랜잭션이 취소되었습니다. 트랜잭션 ID: {}, 취소 이유: {}",
+				decodedPayload.getTransactionId(), decodedPayload.getRevocationReason());
+			return false;
+		}
+
+		// 2. 번들 ID가 앱의 번들 ID와 일치하는지 검증
+		if (!appleBundleId.equals(decodedPayload.getBundleId())) {
+			log.warn("번들 ID 불일치. 예상: {}, 실제: {}",
+				appleBundleId, decodedPayload.getBundleId());
+			return false;
+		}
+
+		// 3. 상품 ID가 요청한 상품과 일치하는지 검증
+		if (!request.getProductId().equals(decodedPayload.getProductId())) {
+			log.warn("상품 ID 불일치. 요청: {}, 응답: {}",
+				request.getProductId(), decodedPayload.getProductId());
+			return false;
+		}
+
+		// 4. 환경 확인 - 프로덕션에서는 프로덕션, 개발에서는 샌드박스인지 확인
+		// boolean isProduction = !"Sandbox".equalsIgnoreCase(decodedPayload.getEnvironment());
+		// if (isProduction) {
+		// 	log.warn("환경 불일치. 프로덕션 여부: {}, 프로덕션이어야 함: {}",
+		// 		isProduction, shouldBeProduction);
+		// 	return false;
+		// }
+
+		// 5. 수량 검증
+		if (decodedPayload.getQuantity() <= 0) {
+			log.warn("유효하지 않은 수량: {}", decodedPayload.getQuantity());
+			return false;
+		}
+
+		// 6. 앱 계정 토큰이 제공된 경우 일치하는지 확인
+		if (request.getAppAccountToken() != null && decodedPayload.getAppAccountToken() != null &&
+			!request.getAppAccountToken().equals(decodedPayload.getAppAccountToken())) {
+			log.warn("앱 계정 토큰 불일치. 요청: {}, 응답: {}",
+				request.getAppAccountToken(), decodedPayload.getAppAccountToken());
+			return false;
+		}
+
+		// 7. 모든 검증이 완료되었으므로 true 반환
+		log.info("Apple IAP Purchase Validation Success. Transaction ID: {}", decodedPayload.getTransactionId());
 		return true;
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/pencil/service/PencilCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/service/PencilCommandService.java
@@ -3,7 +3,6 @@ package umc.th.juinjang.api.pencil.service;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,7 +19,6 @@ import umc.th.juinjang.domain.member.model.Member;
 import umc.th.juinjang.domain.pencil.acquired.model.AcquiredPencil;
 import umc.th.juinjang.domain.pencil.purchased.model.PurchasedPencil;
 import umc.th.juinjang.domain.pencil.purchased.model.TransactionStatus;
-import umc.th.juinjang.event.publisher.PaymentEventPublisher;
 
 @Slf4j
 @Service

--- a/src/main/java/umc/th/juinjang/api/pencil/service/PencilCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/service/PencilCommandService.java
@@ -1,24 +1,26 @@
 package umc.th.juinjang.api.pencil.service;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.apple.itunes.storekit.model.JWSTransactionDecodedPayload;
-
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import umc.th.juinjang.api.apple.service.AppleService;
+import umc.th.juinjang.api.apple.service.command.AppleTransactionVerifyCommand;
 import umc.th.juinjang.api.pencil.controller.request.AppleIAPPurchaseRequest;
 import umc.th.juinjang.api.pencil.service.response.AppleIAPPurchaseResponse;
+import umc.th.juinjang.api.pencil.service.response.VerificationResult;
 import umc.th.juinjang.api.pencilAccount.service.PencilAccountFinder;
 import umc.th.juinjang.domain.member.model.Member;
 import umc.th.juinjang.domain.pencil.acquired.model.AcquiredPencil;
 import umc.th.juinjang.domain.pencil.purchased.model.PurchasedPencil;
-import umc.th.juinjang.domain.pencilaccount.model.PencilAccount;
+import umc.th.juinjang.domain.pencil.purchased.model.TransactionStatus;
+import umc.th.juinjang.event.publisher.PaymentEventPublisher;
 
 @Slf4j
 @Service
@@ -28,11 +30,9 @@ public class PencilCommandService {
 	private final AppleService appleService;
 
 	private final PurchasedPencilUpdater purchasedPencilUpdater;
+	private final PurchasedPencilFinder purchasedPencilFinder;
 	private final AcquiredPencilFinder acquiredPencilFinder;
 	private final PencilAccountFinder pencilAccountFinder;
-
-	@Value("${apple.iap.bundle-id}")
-	String appleBundleId;
 
 	@Transactional
 	public Boolean markAcquiredPencilAsRead(Long acquiredPencilId) {
@@ -50,89 +50,98 @@ public class PencilCommandService {
 	public AppleIAPPurchaseResponse processAppleIAPPurchase(AppleIAPPurchaseRequest request, Member member,
 		LocalDateTime now) {
 		String transactionId = request.getTransactionId();
+
+		Optional<PurchasedPencil> existing = purchasedPencilFinder.findByTransactionIdAndMember(transactionId, member);
+
+		if (existing.isEmpty()) {
+			// 기존 트랜잭션이 없는 경우
+			log.info("기존 트랜잭션이 없습니다. {}", transactionId);
+			return validateAndCommitApplePurchase(request, member, now);
+		}
+
+		PurchasedPencil pencil = existing.get();
+		TransactionStatus status = pencil.getTransactionStatus();
+
+		if (status == TransactionStatus.SUCCESS) {
+			// 트랜잭션이 정상적으로 성공된 기록이 있는 경우
+			return AppleIAPPurchaseResponse.ofSuccess(transactionId);
+		}
+
+		PurchasedPencil newPencil = retryPurchasedPencil(pencil, member); // 실패 재시도 처리
+		return AppleIAPPurchaseResponse.of(transactionId, newPencil.getTransactionStatus());
+	}
+
+
+
+	@Transactional
+	public AppleIAPPurchaseResponse validateAndCommitApplePurchase(AppleIAPPurchaseRequest request, Member member, LocalDateTime now) {
+		String transactionId = request.getTransactionId();
+
+		VerificationResult verificationResult = appleService.verifyAppleTransaction(AppleTransactionVerifyCommand.fromRequest(request));
+
+		if (VerificationResult.isSuccess(verificationResult)){
+			// 성공 시, DB에 저장z
+			handleSuccessfulApplePurchase(request, member, now);
+
+			// TODO : 디스코드 알림 추가 필요
+			// paymentEventPublisher.publishPaymentEvent(member,request.getPrice(), pencilAmount,TransactionStatus.SUCCESS);
+			return AppleIAPPurchaseResponse.ofSuccess(transactionId);
+		}else{
+			// 실패 시, DB에 저장
+			handleFailureApplePurchase(request, member, now);
+
+			// TODO : 디스코드 알림 추가 필요
+			// paymentEventPublisher.publishPaymentEvent(member,request.getPrice(), pencilAmount,TransactionStatus.VALIDATION_FAILED);
+			return AppleIAPPurchaseResponse.ofValidationFailure(transactionId);
+		}
+	}
+
+	@Transactional
+	public void handleSuccessfulApplePurchase(AppleIAPPurchaseRequest request, Member member, LocalDateTime now) {
+		String transactionId = request.getTransactionId();
 		Long pencilAmount = request.getPencilQuantity();
 
-		// 트랜잭션이 중복되는 지 체크가 필요한 가?
-		try{
-			// 1. 애플 서버로부터 트랜잭션 정보 가져오기
-			JWSTransactionDecodedPayload decodedPayload = appleService.getTransactionInfo(transactionId);
+		String title = createTitle(pencilAmount);
+		purchasedPencilUpdater.save(PurchasedPencil.successOf(member, title, pencilAmount, request.getPrice(),
+			request.getPlayTime(), transactionId, request.getAppAccountToken(), now));
 
-			// 2. 서버와의 검증 수행
-			if (!validateTransaction(decodedPayload,request)){
-				// PurchasePencil에 결과 저장
-				return null;
-			}
-
-			PencilAccount pencilAccount = pencilAccountFinder.findByMemberWithLock(member);
-			pencilAccount.increasePurchasedBalance(pencilAmount);
-
-			String title = "연필 10개 구매";
-
-			PurchasedPencil purchasedPencil = PurchasedPencil.createSuccessPurchase(
-				member, title, 10L, pencilAmount, transactionId, request.getAppAccountToken(),now);
-
-			purchasedPencilUpdater.save(purchasedPencil);
-
-			log.info("Apple IAP Purchase Success. Transaction ID: {}, Total Balance Amount: {} , Total Purchase Amount: {}",
-				transactionId, pencilAccount.getTotalBalance(), pencilAccount.getTotalPurchaseAmount());
-			return AppleIAPPurchaseResponse.of(transactionId, pencilAccount.getTotalBalance());
-		}catch (Exception e){
-			return null;
-		}
+		pencilAccountFinder.findByMemberWithLock(member).increasePurchasedBalance(pencilAmount);
 	}
 
-	private boolean validateTransaction(JWSTransactionDecodedPayload decodedPayload, AppleIAPPurchaseRequest request) {
-		// 트랜잭션 아이디가 정상적으로 일치하는 지 여부
-		if (!decodedPayload.getTransactionId().equals(request.getTransactionId())) {
-			log.warn("트랜잭션 아이디 불일치. 애플 PAYLOAD : {}, REQUEST 요청 : {}",decodedPayload.getTransactionId(), request.getTransactionId());
-			return false;
-		}
+	@Transactional
+	public void handleFailureApplePurchase(AppleIAPPurchaseRequest request, Member member, LocalDateTime now) {
+		String transactionId = request.getTransactionId();
+		Long pencilAmount = request.getPencilQuantity();
 
-		// 1. 환불/취소 여부 확인
-		if (decodedPayload.getRevocationDate() != null || decodedPayload.getRevocationReason() != null) {
-			log.warn("트랜잭션이 취소되었습니다. 트랜잭션 ID: {}, 취소 이유: {}",
-				decodedPayload.getTransactionId(), decodedPayload.getRevocationReason());
-			return false;
-		}
-
-		// 2. 번들 ID가 앱의 번들 ID와 일치하는지 검증
-		if (!appleBundleId.equals(decodedPayload.getBundleId())) {
-			log.warn("번들 ID 불일치. 예상: {}, 실제: {}",
-				appleBundleId, decodedPayload.getBundleId());
-			return false;
-		}
-
-		// 3. 상품 ID가 요청한 상품과 일치하는지 검증
-		if (!request.getProductId().equals(decodedPayload.getProductId())) {
-			log.warn("상품 ID 불일치. 요청: {}, 응답: {}",
-				request.getProductId(), decodedPayload.getProductId());
-			return false;
-		}
-
-		// 4. 환경 확인 - 프로덕션에서는 프로덕션, 개발에서는 샌드박스인지 확인
-		// boolean isProduction = !"Sandbox".equalsIgnoreCase(decodedPayload.getEnvironment());
-		// if (isProduction) {
-		// 	log.warn("환경 불일치. 프로덕션 여부: {}, 프로덕션이어야 함: {}",
-		// 		isProduction, shouldBeProduction);
-		// 	return false;
-		// }
-
-		// 5. 수량 검증
-		if (decodedPayload.getQuantity() <= 0) {
-			log.warn("유효하지 않은 수량: {}", decodedPayload.getQuantity());
-			return false;
-		}
-
-		// 6. 앱 계정 토큰이 제공된 경우 일치하는지 확인
-		if (request.getAppAccountToken() != null && decodedPayload.getAppAccountToken() != null &&
-			!request.getAppAccountToken().equals(decodedPayload.getAppAccountToken())) {
-			log.warn("앱 계정 토큰 불일치. 요청: {}, 응답: {}",
-				request.getAppAccountToken(), decodedPayload.getAppAccountToken());
-			return false;
-		}
-
-		// 7. 모든 검증이 완료되었으므로 true 반환
-		log.info("Apple IAP Purchase Validation Success. Transaction ID: {}", decodedPayload.getTransactionId());
-		return true;
+		String title = createTitle(pencilAmount);
+		purchasedPencilUpdater.save(PurchasedPencil.failedDueToValidation(member, title, pencilAmount, request.getPrice(),
+			request.getPlayTime(), transactionId, request.getAppAccountToken(), now));
 	}
+
+	private PurchasedPencil retryPurchasedPencil(PurchasedPencil pencil, Member member) {
+		if ( pencil.getRetryCount() >= 3 ) { // 재시도 횟수가 3회 이상일 경우 실패로 처리
+			return pencil;
+		}
+
+		AppleIAPPurchaseRequest retryRequest = AppleIAPPurchaseRequest.ofRetry(pencil);
+		VerificationResult verificationResult = appleService.verifyAppleTransaction(
+			AppleTransactionVerifyCommand.fromRequest(retryRequest)
+		);
+
+		if (VerificationResult.isSuccess(verificationResult)) {
+			pencil.markAsSuccess();
+			pencil.updateRetryCount(pencil.getRetryCount() + 1);
+
+			pencilAccountFinder.findByMemberWithLock(member)
+				.increasePurchasedBalance(pencil.getPurchaseQuantity());
+		}
+
+		return pencil;
+	}
+
+
+	private String createTitle(Long pencilAmount) {
+		return String.format("연필 %d개 구매", pencilAmount);
+	}
+
 }

--- a/src/main/java/umc/th/juinjang/api/pencil/service/PurchasedPencilFinder.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/service/PurchasedPencilFinder.java
@@ -1,6 +1,7 @@
 package umc.th.juinjang.api.pencil.service;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
@@ -16,5 +17,9 @@ public class PurchasedPencilFinder {
 
 	public List<PurchasedPencil> findAllByMemberWhereDeliverySuccessOrderByCreatedAtDesc(Member member) {
 		return purchasedPencilRepository.findAllByMemberWhereDeliverySuccessOrderByCreatedAtDesc(member);
+	}
+
+	public Optional<PurchasedPencil> findByTransactionIdAndMember(String transactionId, Member member) {
+		return purchasedPencilRepository.findByTransactionIdAndMember(transactionId, member);
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/pencil/service/PurchasedPencilUpdater.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/service/PurchasedPencilUpdater.java
@@ -1,0 +1,18 @@
+package umc.th.juinjang.api.pencil.service;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.domain.pencil.purchased.model.PurchasedPencil;
+import umc.th.juinjang.domain.pencil.purchased.repository.PurchasedPencilRepository;
+
+@Component
+@RequiredArgsConstructor
+public class PurchasedPencilUpdater {
+
+	private final PurchasedPencilRepository purchasedPencilRepository;
+
+	public void save(PurchasedPencil purchasedPencil) {
+		purchasedPencilRepository.save(purchasedPencil);
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/pencil/service/PurchasedPencilUpdater.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/service/PurchasedPencilUpdater.java
@@ -13,7 +13,7 @@ import umc.th.juinjang.domain.pencil.purchased.repository.PurchasedPencilReposit
 @RequiredArgsConstructor
 public class PurchasedPencilUpdater {
 
-	private PurchasedPencilRepository purchasedPencilRepository;
+	private final PurchasedPencilRepository purchasedPencilRepository;
 
 	public List<PurchasedPencil> findByMemberAndDeliverySuccessRemainQuantityGreaterThanOrderByCreatedAtAsc(
 		Member buyer,
@@ -21,5 +21,9 @@ public class PurchasedPencilUpdater {
 		return purchasedPencilRepository.findByMemberAndDeliverySuccessAndRemainQuantityGreaterThanOrderByCreatedAtAsc(
 			buyer,
 			remainQuantity);
+	}
+
+	public void save(PurchasedPencil successPurchase) {
+		purchasedPencilRepository.save(successPurchase);
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/pencil/service/response/AppleIAPPurchaseResponse.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/service/response/AppleIAPPurchaseResponse.java
@@ -2,22 +2,37 @@ package umc.th.juinjang.api.pencil.service.response;
 
 import lombok.Builder;
 import lombok.Getter;
+import umc.th.juinjang.domain.pencil.purchased.model.TransactionStatus;
 
 @Getter
 public class AppleIAPPurchaseResponse {
 
-	private Long pencilQuantity;
+	private TransactionStatus status;
 	private String transactionId;
 
 	@Builder
-	private AppleIAPPurchaseResponse(Long pencilQuantity, String transactionId) {
-		this.pencilQuantity = pencilQuantity;
+	private AppleIAPPurchaseResponse(TransactionStatus status,String transactionId) {
+		this.status = status;
 		this.transactionId = transactionId;
 	}
 
-	public static AppleIAPPurchaseResponse of(String transactionId, Long pencilQuantity) {
+	public static AppleIAPPurchaseResponse of(String transactionId, TransactionStatus status) {
 		return AppleIAPPurchaseResponse.builder()
-			.pencilQuantity(pencilQuantity)
+			.transactionId(transactionId)
+			.status(status)
+			.build();
+	}
+
+	public static AppleIAPPurchaseResponse ofSuccess(String transactionId) {
+		return AppleIAPPurchaseResponse.builder()
+			.status(TransactionStatus.SUCCESS)
+			.transactionId(transactionId)
+			.build();
+	}
+
+	public static AppleIAPPurchaseResponse ofValidationFailure(String transactionId) {
+		return AppleIAPPurchaseResponse.builder()
+			.status(TransactionStatus.VALIDATION_FAILED)
 			.transactionId(transactionId)
 			.build();
 	}

--- a/src/main/java/umc/th/juinjang/api/pencil/service/response/AppleIAPPurchaseResponse.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/service/response/AppleIAPPurchaseResponse.java
@@ -1,0 +1,24 @@
+package umc.th.juinjang.api.pencil.service.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AppleIAPPurchaseResponse {
+
+	private Long pencilQuantity;
+	private String transactionId;
+
+	@Builder
+	private AppleIAPPurchaseResponse(Long pencilQuantity, String transactionId) {
+		this.pencilQuantity = pencilQuantity;
+		this.transactionId = transactionId;
+	}
+
+	public static AppleIAPPurchaseResponse of(String transactionId, Long pencilQuantity) {
+		return AppleIAPPurchaseResponse.builder()
+			.pencilQuantity(pencilQuantity)
+			.transactionId(transactionId)
+			.build();
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/pencil/service/response/PurchasedPencilResponse.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/service/response/PurchasedPencilResponse.java
@@ -13,17 +13,17 @@ public class PurchasedPencilResponse {
 	private Long remainQuantity;
 	private String title;
 	private Long price;
-	private LocalDateTime createdAt;
+	private LocalDateTime purchasedAt;
 
 	@Builder
 	public PurchasedPencilResponse(Long purchasePencilId, Long purchaseQuantity, Long remainQuantity,
-		String title, Long price, LocalDateTime createdAt) {
+		String title, Long price, LocalDateTime purchasedAt) {
 		this.purchasePencilId = purchasePencilId;
 		this.purchaseQuantity = purchaseQuantity;
 		this.remainQuantity = remainQuantity;
 		this.title = title;
 		this.price = price;
-		this.createdAt = createdAt;
+		this.purchasedAt = purchasedAt;
 	}
 
 	public static PurchasedPencilResponse from(PurchasedPencil purchasedPencil) {
@@ -33,7 +33,7 @@ public class PurchasedPencilResponse {
 			.remainQuantity(purchasedPencil.getRemainQuantity())
 			.title(purchasedPencil.getTitle())
 			.price(purchasedPencil.getPrice())
-			.createdAt(purchasedPencil.getCreatedAt())
+			.purchasedAt(purchasedPencil.getPurchasedAt())
 			.build();
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/pencil/service/response/VerificationResult.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/service/response/VerificationResult.java
@@ -1,0 +1,38 @@
+package umc.th.juinjang.api.pencil.service.response;
+
+import com.apple.itunes.storekit.model.JWSTransactionDecodedPayload;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class VerificationResult {
+
+
+	public enum Status { SUCCESS, INVALID, IO_ERROR, SERVER_ERROR, VERIFICATION_ERROR }
+
+	private final Status status;
+	private final JWSTransactionDecodedPayload payload;
+
+	@Builder
+	private VerificationResult(Status status, JWSTransactionDecodedPayload payload) {
+		this.status = status;
+		this.payload = payload;
+	}
+
+	public static VerificationResult ofSuccess(JWSTransactionDecodedPayload payload) {
+		 return VerificationResult.builder().status(Status.SUCCESS).payload(payload).build();
+	}
+
+	public static VerificationResult ofServerError() {
+		return VerificationResult.builder().status(Status.SERVER_ERROR).build();
+	}
+
+	public static VerificationResult ofVerificationError() {
+		return VerificationResult.builder().status(Status.VERIFICATION_ERROR).build();
+	}
+
+	public static boolean isSuccess(VerificationResult verificationResult) {
+		return verificationResult.getStatus() == Status.SUCCESS;
+	}
+}

--- a/src/main/java/umc/th/juinjang/domain/pencil/purchased/model/PurchasedPencil.java
+++ b/src/main/java/umc/th/juinjang/domain/pencil/purchased/model/PurchasedPencil.java
@@ -4,9 +4,14 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.DynamicUpdate;
+import org.springframework.data.annotation.LastModifiedDate;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -16,13 +21,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import umc.th.juinjang.domain.common.BaseEntity;
 import umc.th.juinjang.domain.member.model.Member;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicUpdate
 @Entity
-public class PurchasedPencil extends BaseEntity {
+public class PurchasedPencil {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,71 +38,106 @@ public class PurchasedPencil extends BaseEntity {
 	private Member member;
 
 	private String title;
-
 	private Long purchaseQuantity;
-
 	private Long remainQuantity;
-
 	private Long price;
 
 	@Comment("애플 인앱 결제에서, 프론트에서 전달해주는 트랜잭션 아이디")
 	private String transactionId;
 
+	@Comment("애플 인앱 결제에서, 프론트에서 전달해주는 애플 앱 토큰")
 	private UUID appAccountToken;
 
 	@Convert(converter = DeliveryStatusConverter.class)
 	private DeliveryStatus deliveryStatus;
 
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private TransactionStatus transactionStatus;
+
+	private Long playTime;
+
+	private Long retryCount = 0L;
+
+	private LocalDateTime purchasedAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
 	@Builder
 	public PurchasedPencil(Member member, String title, Long purchaseQuantity,
-		Long remainQuantity,
+		Long remainQuantity, TransactionStatus transactionStatus, Long playTime,
 		Long price, String transactionId, UUID appAccountToken, DeliveryStatus deliveryStatus,
-		LocalDateTime createdAt) {
+		LocalDateTime purchasedAt) {
 		this.member = member;
 		this.title = title;
 		this.purchaseQuantity = purchaseQuantity;
 		this.remainQuantity = remainQuantity;
 		this.price = price;
+		this.playTime = playTime;
 		this.transactionId = transactionId;
 		this.appAccountToken = appAccountToken;
 		this.deliveryStatus = deliveryStatus;
-		setCreatedAt(createdAt);
+		this.transactionStatus = transactionStatus;
+		this.purchasedAt = purchasedAt;
 	}
 
-	public static PurchasedPencil createSuccessPurchase(Member member, String title,
-		Long purchaseQuantity, Long price,
-		String transactionId, UUID appAccountToken, LocalDateTime createdAt) {
-		return PurchasedPencil.builder()
-			.member(member)
-			.title(title)
-			.purchaseQuantity(purchaseQuantity)
-			.remainQuantity(purchaseQuantity)
-			.price(price)
-			.transactionId(transactionId)
-			.appAccountToken(appAccountToken)
-			.deliveryStatus(DeliveryStatus.DELIVERY_SUCCESS)
-			.createdAt(createdAt)
-			.build();
-	}
-
-	public static PurchasedPencil createServerErrorPurchase(Member member, String title,
-		Long purchaseQuantity, Long price,
-		String transactionId, UUID appAccountToken, LocalDateTime createdAt) {
-		return PurchasedPencil.builder()
-			.member(member)
-			.title(title)
-			.purchaseQuantity(purchaseQuantity)
-			.remainQuantity(purchaseQuantity)
-			.price(price)
-			.transactionId(transactionId)
-			.appAccountToken(appAccountToken)
-			.deliveryStatus(DeliveryStatus.SERVER_ERROR)
-			.createdAt(createdAt)
-			.build();
-	}
-	
 	public void decreaseRemainQuantity(long quantity) {
 		this.remainQuantity -= quantity;
 	}
+
+	public void markAsSuccess(){
+		this.transactionStatus = TransactionStatus.SUCCESS;
+		this.deliveryStatus = DeliveryStatus.DELIVERY_SUCCESS;
+	}
+
+	public void updateRetryCount(Long retryCount) {
+		this.retryCount = retryCount;
+	}
+
+	private static PurchasedPencilBuilder baseBuilder(
+		Member member, String title, Long quantity, Long price,
+		Long playTime, String transactionId, UUID token, LocalDateTime purchasedAt
+	) {
+		return PurchasedPencil.builder()
+			.member(member)
+			.title(title)
+			.purchaseQuantity(quantity)
+			.remainQuantity(quantity)
+			.price(price)
+			.playTime(playTime)
+			.transactionId(transactionId)
+			.appAccountToken(token)
+			.purchasedAt(purchasedAt);
+	}
+
+	// ✅ 결제 성공
+	public static PurchasedPencil successOf(Member member, String title, Long quantity,
+		Long price, Long playTime, String transactionId,
+		UUID token, LocalDateTime purchasedAt) {
+		return baseBuilder(member, title, quantity, price, playTime, transactionId, token, purchasedAt)
+			.transactionStatus(TransactionStatus.SUCCESS)
+			.deliveryStatus(DeliveryStatus.DELIVERY_SUCCESS)
+			.build();
+	}
+
+	// ✅ 서버 에러
+	public static PurchasedPencil failedDueToServerError(Member member, String title, Long quantity,
+		Long price, Long playTime, String transactionId, UUID token, LocalDateTime purchasedAt) {
+		return baseBuilder(member, title, quantity, price, playTime, transactionId, token, purchasedAt)
+			.transactionStatus(TransactionStatus.DB_FAILED)
+			.deliveryStatus(DeliveryStatus.SERVER_ERROR)
+			.build();
+	}
+
+	// ✅ 검증 실패
+	public static PurchasedPencil failedDueToValidation(Member member, String title, Long quantity,
+		Long price, Long playTime, String transactionId, UUID token, LocalDateTime purchasedAt) {
+		return baseBuilder(member, title, quantity, price, playTime, transactionId, token, purchasedAt)
+			.transactionStatus(TransactionStatus.VALIDATION_FAILED)
+			.deliveryStatus(DeliveryStatus.OTHER_REASONS)
+			.build();
+	}
 }
+
 

--- a/src/main/java/umc/th/juinjang/domain/pencil/purchased/model/TransactionStatus.java
+++ b/src/main/java/umc/th/juinjang/domain/pencil/purchased/model/TransactionStatus.java
@@ -1,0 +1,8 @@
+package umc.th.juinjang.domain.pencil.purchased.model;
+
+public enum TransactionStatus {
+	// PENDING,
+	SUCCESS,
+	VALIDATION_FAILED,
+	DB_FAILED;
+}

--- a/src/main/java/umc/th/juinjang/domain/pencil/purchased/repository/PurchasedPencilRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/pencil/purchased/repository/PurchasedPencilRepository.java
@@ -1,6 +1,7 @@
 package umc.th.juinjang.domain.pencil.purchased.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,11 +12,14 @@ import umc.th.juinjang.domain.pencil.purchased.model.PurchasedPencil;
 
 public interface PurchasedPencilRepository extends JpaRepository<PurchasedPencil, Long> {
 
-	@Query("SELECT p FROM PurchasedPencil p WHERE p.member = :member AND p.deliveryStatus = 0 ORDER BY p.createdAt DESC")
+	@Query("SELECT p FROM PurchasedPencil p WHERE p.member = :member AND p.deliveryStatus = 0 ORDER BY p.purchasedAt DESC")
 	List<PurchasedPencil> findAllByMemberWhereDeliverySuccessOrderByCreatedAtDesc(@Param("member") Member member);
 
-	@Query("select p from PurchasedPencil p where p.member = :member and p.remainQuantity > :remainQuantity AND p.deliveryStatus = 0 order by p.createdAt asc")
+	@Query("select p from PurchasedPencil p where p.member = :member and p.remainQuantity > :remainQuantity AND p.deliveryStatus = 0 order by p.purchasedAt asc")
 	List<PurchasedPencil> findByMemberAndDeliverySuccessAndRemainQuantityGreaterThanOrderByCreatedAtAsc(
 		@Param("member") Member buyer,
 		@Param("remainQuantity") Long remainQuantity);
+
+	Optional<PurchasedPencil> findByTransactionIdAndMember(String transactionId, Member member);
+
 }

--- a/src/main/java/umc/th/juinjang/domain/pencilaccount/model/PencilAccount.java
+++ b/src/main/java/umc/th/juinjang/domain/pencilaccount/model/PencilAccount.java
@@ -1,6 +1,7 @@
 package umc.th.juinjang.domain.pencilaccount.model;
 
 import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.DynamicUpdate;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -19,6 +20,7 @@ import umc.th.juinjang.domain.member.model.Member;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@DynamicUpdate
 public class PencilAccount extends BaseEntity {
 
 	@Id
@@ -68,6 +70,13 @@ public class PencilAccount extends BaseEntity {
 
 	public void increaseAcquiredBalance(long price) {
 		this.acquiredBalance += price;
+		this.totalBalance = this.purchasedBalance + this.acquiredBalance;
+	}
+
+	public void increasePurchasedBalance(long price) {
+		this.purchasedBalance += price;
+		this.totalPurchaseAmount += price;
+
 		this.totalBalance = this.purchasedBalance + this.acquiredBalance;
 	}
 

--- a/src/test/java/umc/th/juinjang/api/ControllerTestSupport.java
+++ b/src/test/java/umc/th/juinjang/api/ControllerTestSupport.java
@@ -8,6 +8,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import umc.th.juinjang.api.pencil.controller.PencilController;
+import umc.th.juinjang.api.pencil.service.PencilCommandService;
 import umc.th.juinjang.api.pencil.service.PencilQueryService;
 import umc.th.juinjang.api.pencilAccount.controller.PencilAccountController;
 import umc.th.juinjang.api.pencilAccount.service.PencilAccountService;
@@ -29,4 +30,7 @@ public abstract class ControllerTestSupport {
 
 	@MockBean
 	protected PencilQueryService pencilQueryService;
+
+	@MockBean
+	protected PencilCommandService pencilCommandService;
 }

--- a/src/test/java/umc/th/juinjang/api/ControllerTestSupport.java
+++ b/src/test/java/umc/th/juinjang/api/ControllerTestSupport.java
@@ -8,7 +8,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import umc.th.juinjang.api.pencil.controller.PencilController;
-import umc.th.juinjang.api.pencil.service.AcquiredPencilService;
+import umc.th.juinjang.api.pencil.service.PencilQueryService;
 import umc.th.juinjang.api.pencilAccount.controller.PencilAccountController;
 import umc.th.juinjang.api.pencilAccount.service.PencilAccountService;
 
@@ -28,5 +28,5 @@ public abstract class ControllerTestSupport {
 	protected PencilAccountService pencilAccountService;
 
 	@MockBean
-	protected AcquiredPencilService acquiredPencilService;
+	protected PencilQueryService pencilQueryService;
 }

--- a/src/test/java/umc/th/juinjang/api/pencil/service/PencilCommandServiceTest.java
+++ b/src/test/java/umc/th/juinjang/api/pencil/service/PencilCommandServiceTest.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,10 +22,13 @@ import com.apple.itunes.storekit.verification.VerificationException;
 import lombok.extern.slf4j.Slf4j;
 import umc.th.juinjang.api.IntegrationTestSupport;
 import umc.th.juinjang.api.apple.service.AppleService;
+import umc.th.juinjang.api.apple.service.command.AppleTransactionVerifyCommand;
 import umc.th.juinjang.api.pencil.controller.request.AppleIAPPurchaseRequest;
 import umc.th.juinjang.api.pencil.service.response.AppleIAPPurchaseResponse;
+import umc.th.juinjang.api.pencil.service.response.VerificationResult;
 import umc.th.juinjang.domain.member.model.Member;
 import umc.th.juinjang.domain.member.repository.MemberRepository;
+import umc.th.juinjang.domain.pencil.purchased.model.TransactionStatus;
 import umc.th.juinjang.domain.pencil.purchased.repository.PurchasedPencilRepository;
 import umc.th.juinjang.domain.pencilaccount.model.PencilAccount;
 import umc.th.juinjang.domain.pencilaccount.repository.PencilAccountRepository;
@@ -82,25 +86,60 @@ public class PencilCommandServiceTest extends IntegrationTestSupport {
 		payload.setQuantity(20);
 		payload.setTransactionId(transactionId);
 
-		when(appleService.getTransactionInfo(transactionId)).thenReturn(payload);
+		when(appleService.verifyAppleTransaction(any(AppleTransactionVerifyCommand.class)))
+			.thenReturn(VerificationResult.ofSuccess(payload));
 
 		// when
 		AppleIAPPurchaseResponse response = pencilService.processAppleIAPPurchase(request, member,now);
 
 		// then
 		log.info("[RESPONSE - TRANSACTION_ID]: {}", response.getTransactionId());
-		log.info("[RESPONSE - PENCIL_QUANTITY]: {}", response.getPencilQuantity());
 
 		assertThat(response).isNotNull();
-		assertThat(response.getPencilQuantity()).isEqualTo(20L);
 		assertThat(response.getTransactionId()).isEqualTo(transactionId);
+		assertThat(response.getStatus()).isEqualTo(TransactionStatus.SUCCESS);
+	}
+
+	@DisplayName("애플 인앱 결제 중에 유효성 검증에서 실패한 경우 (트랜잭션 아이디가 불일치) 에 대한 테스트 진행")
+	@Test
+	void processAppleIAPPurchase_Validation_Fail() throws APIException, VerificationException, IOException {
+		// given
+		Member member = MemberFixture.createDefaultMember();
+		memberRepository.save(member);
+
+		PencilAccount pencilAccount = PencilAccount.createPencilAccount(member);
+		pencilAccountRepository.save(pencilAccount);
+
+		// when
+		AppleIAPPurchaseRequest request = createValidRequest();
+		LocalDateTime now = LocalDateTime.now();
+
+		String payloadTransactionId = "invalidTransactionId";
+		JWSTransactionDecodedPayload payload = new JWSTransactionDecodedPayload();
+		payload.setProductId(productId);
+		payload.setAppAccountToken(appAccountToken);
+		payload.setBundleId(bundleId);
+		payload.setQuantity(20);
+		payload.setTransactionId(payloadTransactionId);
+
+		// then
+		when(appleService.verifyAppleTransaction(any(AppleTransactionVerifyCommand.class)))
+			.thenReturn(VerificationResult.ofVerificationError());
+
+		// when
+		AppleIAPPurchaseResponse response = pencilService.processAppleIAPPurchase(request, member,now);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.getTransactionId()).isEqualTo(transactionId);
+		assertThat(response.getStatus()).isEqualTo(TransactionStatus.VALIDATION_FAILED);
 	}
 
 
 
 	private AppleIAPPurchaseRequest createValidRequest() {
 		return AppleIAPPurchaseRequest
-			.of(transactionId, appAccountToken, 20L, 3000L, productId);
+			.of(transactionId, appAccountToken, 20L, 3000L, productId,10L);
 	}
 }
 

--- a/src/test/java/umc/th/juinjang/api/pencil/service/PencilCommandServiceTest.java
+++ b/src/test/java/umc/th/juinjang/api/pencil/service/PencilCommandServiceTest.java
@@ -1,0 +1,104 @@
+package umc.th.juinjang.api.pencil.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import com.apple.itunes.storekit.client.APIException;
+import com.apple.itunes.storekit.model.JWSTransactionDecodedPayload;
+import com.apple.itunes.storekit.verification.VerificationException;
+
+import lombok.extern.slf4j.Slf4j;
+import umc.th.juinjang.api.IntegrationTestSupport;
+import umc.th.juinjang.api.apple.service.AppleService;
+import umc.th.juinjang.api.pencil.controller.request.AppleIAPPurchaseRequest;
+import umc.th.juinjang.api.pencil.service.response.AppleIAPPurchaseResponse;
+import umc.th.juinjang.domain.member.model.Member;
+import umc.th.juinjang.domain.member.repository.MemberRepository;
+import umc.th.juinjang.domain.pencil.purchased.repository.PurchasedPencilRepository;
+import umc.th.juinjang.domain.pencilaccount.model.PencilAccount;
+import umc.th.juinjang.domain.pencilaccount.repository.PencilAccountRepository;
+import umc.th.juinjang.testutil.fixture.MemberFixture;
+
+@Slf4j
+public class PencilCommandServiceTest extends IntegrationTestSupport {
+
+	@Value("${apple.iap.bundle-id}")
+	private String bundleId;
+
+	private final String transactionId = "transactionId";
+	private final UUID appAccountToken = UUID.randomUUID();
+	private final String productId = "productId";
+
+	@Autowired
+	private PencilCommandService pencilService;
+
+	@Autowired
+	private PurchasedPencilRepository purchasedPencilRepository;
+
+	@Autowired
+	private PencilAccountRepository pencilAccountRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@MockBean
+	private AppleService appleService;
+
+	@AfterEach
+	void tearDown() {
+		purchasedPencilRepository.deleteAllInBatch();
+		pencilAccountRepository.deleteAllInBatch();
+		memberRepository.deleteAllInBatch();
+	}
+
+	@DisplayName("애플 인앱 결제과 정상적으로 진행됩니다.")
+	@Test
+	void processAppleIAPPurchase_Success() throws APIException, VerificationException, IOException {
+		// given
+		Member member = MemberFixture.createDefaultMember();
+		memberRepository.save(member);
+
+		PencilAccount pencilAccount = PencilAccount.createPencilAccount(member);
+		pencilAccountRepository.save(pencilAccount);
+
+		AppleIAPPurchaseRequest request = createValidRequest();
+		LocalDateTime now = LocalDateTime.now();
+
+		JWSTransactionDecodedPayload payload = new JWSTransactionDecodedPayload();
+		payload.setProductId(productId);
+		payload.setAppAccountToken(appAccountToken);
+		payload.setBundleId(bundleId);
+		payload.setQuantity(20);
+
+		when(appleService.getTransactionInfo(transactionId)).thenReturn(payload);
+
+		// when
+		AppleIAPPurchaseResponse response = pencilService.processAppleIAPPurchase(request, member,now);
+		log.info("[RESPONSE - PENCIL_QUANTITY]: {}", response.getPencilQuantity());
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.getPencilQuantity()).isEqualTo(20L);
+		assertThat(response.getTransactionId()).isEqualTo(transactionId);
+	}
+
+
+
+	private AppleIAPPurchaseRequest createValidRequest() {
+		return AppleIAPPurchaseRequest.of(
+			transactionId, appAccountToken, 20L, 3000L, productId);
+	}
+}
+
+

--- a/src/test/java/umc/th/juinjang/api/pencil/service/PencilCommandServiceTest.java
+++ b/src/test/java/umc/th/juinjang/api/pencil/service/PencilCommandServiceTest.java
@@ -80,14 +80,17 @@ public class PencilCommandServiceTest extends IntegrationTestSupport {
 		payload.setAppAccountToken(appAccountToken);
 		payload.setBundleId(bundleId);
 		payload.setQuantity(20);
+		payload.setTransactionId(transactionId);
 
 		when(appleService.getTransactionInfo(transactionId)).thenReturn(payload);
 
 		// when
 		AppleIAPPurchaseResponse response = pencilService.processAppleIAPPurchase(request, member,now);
-		log.info("[RESPONSE - PENCIL_QUANTITY]: {}", response.getPencilQuantity());
 
 		// then
+		log.info("[RESPONSE - TRANSACTION_ID]: {}", response.getTransactionId());
+		log.info("[RESPONSE - PENCIL_QUANTITY]: {}", response.getPencilQuantity());
+
 		assertThat(response).isNotNull();
 		assertThat(response.getPencilQuantity()).isEqualTo(20L);
 		assertThat(response.getTransactionId()).isEqualTo(transactionId);
@@ -96,8 +99,8 @@ public class PencilCommandServiceTest extends IntegrationTestSupport {
 
 
 	private AppleIAPPurchaseRequest createValidRequest() {
-		return AppleIAPPurchaseRequest.of(
-			transactionId, appAccountToken, 20L, 3000L, productId);
+		return AppleIAPPurchaseRequest
+			.of(transactionId, appAccountToken, 20L, 3000L, productId);
 	}
 }
 

--- a/src/test/java/umc/th/juinjang/api/pencil/service/PencilCommandServiceTest.java
+++ b/src/test/java/umc/th/juinjang/api/pencil/service/PencilCommandServiceTest.java
@@ -8,7 +8,6 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/umc/th/juinjang/api/pencil/service/PencilQueryServiceTest.java
+++ b/src/test/java/umc/th/juinjang/api/pencil/service/PencilQueryServiceTest.java
@@ -156,11 +156,11 @@ class PencilQueryServiceTest extends IntegrationTestSupport {
 		UUID uuid5 = UUID.randomUUID();
 
 		// 명확한 순서로 데이터 생성 (시간 역순으로)
-		PurchasedPencil pencil1 = createSuccessPurchase(member, "10개 연필팩", 10L, 1000L, "transaction1", uuid1, time1);
-		PurchasedPencil pencil2 = createSuccessPurchase(member, "20개 연필팩", 20L, 2000L, "transaction2", uuid2, time2);
-		PurchasedPencil pencil3 = createSuccessPurchase(member, "30개 연필팩", 30L, 3000L, "transaction3", uuid3, time3);
-		PurchasedPencil pencil4 = createSuccessPurchase(member, "15개 연필팩", 15L, 1500L, "transaction4", uuid4, time4);
-		PurchasedPencil pencil5 = createSuccessPurchase(member, "25개 연필팩", 25L, 2500L, "transaction5", uuid5, time5);
+		PurchasedPencil pencil1 = PurchasedPencil.successOf(member, "10개 연필팩", 10L, 1000L, 0L,"transaction1", uuid1, time1);
+		PurchasedPencil pencil2 = PurchasedPencil.successOf(member, "20개 연필팩", 20L, 2000L, 0L,"transaction2", uuid2, time2);
+		PurchasedPencil pencil3 = PurchasedPencil.successOf(member, "30개 연필팩", 30L, 3000L,0L ,"transaction3", uuid3, time3);
+		PurchasedPencil pencil4 = PurchasedPencil.successOf(member, "15개 연필팩", 15L, 1500L, 0L,"transaction4", uuid4, time4);
+		PurchasedPencil pencil5 = PurchasedPencil.successOf(member, "25개 연필팩", 25L, 2500L, 0L,"transaction5", uuid5, time5);
 
 		purchasedPencilRepository.saveAll(List.of(pencil1, pencil2, pencil3, pencil4, pencil5));
 
@@ -168,7 +168,7 @@ class PencilQueryServiceTest extends IntegrationTestSupport {
 		List<PurchasedPencilResponse> purchasedPencils = pencilService.getPurchasedPencils(member);
 
 		purchasedPencils.forEach(pencil -> {
-				log.info("[PENCILS]: CREATED_AT : {} ", pencil.getCreatedAt());
+				log.info("[PENCILS]: CREATED_AT : {} ", pencil.getPurchasedAt());
 			}
 		);
 		// then
@@ -193,8 +193,7 @@ class PencilQueryServiceTest extends IntegrationTestSupport {
 		LocalDateTime time = LocalDateTime.now();
 		UUID uuid = UUID.randomUUID();
 
-		PurchasedPencil pencil = createServerErrorPurchase(member, "10개 연필팩", 10L, 1000L, "transaction1", uuid,
-			time);
+		PurchasedPencil pencil = PurchasedPencil.failedDueToServerError(member, "10개 연필팩", 10L, 1000L, 10L,"transaction1", uuid, time);
 
 		purchasedPencilRepository.saveAll(List.of(pencil));
 

--- a/src/test/java/umc/th/juinjang/api/pencil/service/PencilQueryServiceTest.java
+++ b/src/test/java/umc/th/juinjang/api/pencil/service/PencilQueryServiceTest.java
@@ -31,7 +31,7 @@ import umc.th.juinjang.domain.pencil.used.repository.UsedPencilRepository;
 import umc.th.juinjang.testutil.fixture.MemberFixture;
 
 @Slf4j
-class PencilServiceTest extends IntegrationTestSupport {
+class PencilQueryServiceTest extends IntegrationTestSupport {
 
 	@Autowired
 	private MemberRepository memberRepository;

--- a/src/test/java/umc/th/juinjang/repository/limjang/LimjangQuerydslTest.java
+++ b/src/test/java/umc/th/juinjang/repository/limjang/LimjangQuerydslTest.java
@@ -44,27 +44,27 @@ public class LimjangQuerydslTest {
       memberRepository.save(member);
     }
 
-    @Test
-    @DisplayName("키워드를 전달하면 멤버가 소유한 게시글 중 닉네임, 주소, 상세주소 컬럼중 하나라도 키워드를 포함하는 게시글을 리턴한다.")
-    void testIncludeKeyword() {
-
-      // given
-      Limjang limjang1 = createLimjang(member, "경기도 구리시 인창동", "삼성아파트", "우리 집");
-      Limjang limjang2 = createLimjang(member, "경기도 구리시", "인창", "우리 집");
-      Limjang limjang3 = createLimjang(member, "경기도 구리시", "어쩌구", "인창");
-      limjangRepository.saveAll(List.of(limjang1, limjang2, limjang3));
-
-      // when
-      String keyword = "인창";
-      List<Limjang> findLimjangs = limjangRepository.searchLimjangsWhereDeletedIsFalse(member, keyword);
-      // then
-
-      for (int i = 0; i < findLimjangs.size(); i++) {
-        System.out.println(findLimjangs.get(i).getLimjangId());
-      }
-      assertThat(findLimjangs)
-          .hasSize(3);
-    }
+    // @Test
+    // @DisplayName("키워드를 전달하면 멤버가 소유한 게시글 중 닉네임, 주소, 상세주소 컬럼중 하나라도 키워드를 포함하는 게시글을 리턴한다.")
+    // void testIncludeKeyword() {
+    //
+    //   // given
+    //   Limjang limjang1 = createLimjang(member, "경기도 구리시 인창동", "삼성아파트", "우리 집");
+    //   Limjang limjang2 = createLimjang(member, "경기도 구리시", "인창", "우리 집");
+    //   Limjang limjang3 = createLimjang(member, "경기도 구리시", "어쩌구", "인창");
+    //   limjangRepository.saveAll(List.of(limjang1, limjang2, limjang3));
+    //
+    //   // when
+    //   String keyword = "인창";
+    //   List<Limjang> findLimjangs = limjangRepository.searchLimjangsWhereDeletedIsFalse(member, keyword);
+    //   // then
+    //
+    //   for (int i = 0; i < findLimjangs.size(); i++) {
+    //     System.out.println(findLimjangs.get(i).getLimjangId());
+    //   }
+    //   assertThat(findLimjangs)
+    //       .hasSize(3);
+    // }
 
     @Test
     @DisplayName("주소, 상세주소, 닉네임 중 하나라도 키워드를 포함하지 않는 게시글은 검색에 걸리지 않음")


### PR DESCRIPTION
## 작업내용
- 애플 인앱 결제 구현 
   - 애플 검증 구현 
   - 구매 시에, 구매한 연필, 연필 계좌에 저장하도록 설정 

## 상세설명_ & 캡쳐

```		
Optional<PurchasedPencil> existing = purchasedPencilFinder.findByTransactionIdAndMember(transactionId, member);
```

- 프론트에게, 네트워크 에러 등 정상적인 HttpStatus 200 을 받지 못했을 경우에, 3번까지 재시도 하도록 요청
- 중복으로 API 가 들어올 수 있는 경우를 생각해서, 존재하는 지 체크하고 해당 여부에 따라 로직을 다르게 처리 

```
@Retryable(
		maxAttempts = 3,
		backoff = @Backoff(delay = 1000),
		retryFor = { APIException.class, IOException.class, VerificationException.class })
	public JWSTransactionDecodedPayload getTransactionInfo(String transactionId) throws APIException, IOException, VerificationException {
		log.info("Executing GetTransactionInfo for TRANSACTION_ID: {} - Thread: {}",
			transactionId, Thread.currentThread().getName());

		TransactionInfoResponse transactionInfo = appStoreServerAPIClient.getTransactionInfo(transactionId);
		return signedDataVerifier.verifyAndDecodeTransaction(transactionInfo.getSignedTransactionInfo());
	} 
```

- 애플 라이브러리를 통해서, 트랜잭션 정보를 호출하는 API  호출 
- Retryable 어노테이션을 통해, 최대 3회까지 API 에러 호출

- 해당 Merge 시에 yml 이 추가적으로 변경되어야 합니다. 
- 또한, cd.yml 또한 변경 되어야 합니다!!

TODO : 

- DB 저장시에 에러가 발생 시에, 스프링 메모리 또는 Redis 에 Request 정보를 저장해놓고, 특정 경우에 해당 데이터를 DB 로 다시 옮길 예정