### PR TITLE
[refactor/#377] checklist 답변 생성 및 수정시 isSharable 업데이트 추가

### DIFF
--- a/src/main/java/umc/th/juinjang/api/checklist/controller/ChecklistControllerV2.java
+++ b/src/main/java/umc/th/juinjang/api/checklist/controller/ChecklistControllerV2.java
@@ -2,15 +2,24 @@ package umc.th.juinjang.api.checklist.controller;
 
 import java.util.List;
 
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.api.checklist.controller.request.ChecklistAnswerRequestDTO;
+import umc.th.juinjang.api.checklist.service.ChecklistCommandServiceV2;
 import umc.th.juinjang.api.checklist.service.ChecklistQueryServiceV2;
+import umc.th.juinjang.api.checklist.service.response.ChecklistAnswerAndReportResponseDTO;
 import umc.th.juinjang.api.checklist.service.response.ChecklistAnswerResponseDTO;
 import umc.th.juinjang.api.checklist.service.response.ReportResponseDTO;
 import umc.th.juinjang.api.dto.ApiResponse;
-
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v2")
@@ -19,6 +28,7 @@ import org.springframework.web.bind.annotation.*;
 public class ChecklistControllerV2 {
 
 	private final ChecklistQueryServiceV2 checklistQueryService;
+	private final ChecklistCommandServiceV2 checklistCommandService;
 
 	@CrossOrigin
 	@Operation(summary = "체크리스트 답변 조회")
@@ -35,4 +45,14 @@ public class ChecklistControllerV2 {
 		@PathVariable(name = "noteId") Long noteId) {
 		return ApiResponse.onSuccess(checklistQueryService.getReportByNoteId(noteId));
 	}
+
+	@CrossOrigin
+	@Operation(summary = "체크리스트 답변 생성/수정")
+	@PostMapping("/checklist/{limjangId}")
+	public ApiResponse<ChecklistAnswerAndReportResponseDTO> postChecklistAnswer(
+		@PathVariable(name = "limjangId") Long limjangId,
+		@RequestBody List<ChecklistAnswerRequestDTO.AnswerDto> answerDtos) {
+		return ApiResponse.onSuccess(checklistCommandService.saveChecklistAnswerList(limjangId, answerDtos));
+	}
+
 }

--- a/src/main/java/umc/th/juinjang/api/checklist/service/ChecklistCommandServiceV2.java
+++ b/src/main/java/umc/th/juinjang/api/checklist/service/ChecklistCommandServiceV2.java
@@ -1,0 +1,195 @@
+package umc.th.juinjang.api.checklist.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import umc.th.juinjang.api.checklist.controller.request.ChecklistAnswerRequestDTO;
+import umc.th.juinjang.api.checklist.service.converter.ChecklistAnswerAndReportConverter;
+import umc.th.juinjang.api.checklist.service.response.ChecklistAnswerAndReportResponseDTO;
+import umc.th.juinjang.api.limjang.service.NoteFinder;
+import umc.th.juinjang.api.limjang.service.NoteQueryServiceV2;
+import umc.th.juinjang.api.limjang.service.NoteUpdater;
+import umc.th.juinjang.api.limjang.service.response.ChecklistConditionResponse;
+import umc.th.juinjang.common.code.status.ErrorStatus;
+import umc.th.juinjang.common.exception.handler.ChecklistHandler;
+import umc.th.juinjang.common.exception.handler.LimjangHandler;
+import umc.th.juinjang.domain.checklist.model.ChecklistAnswer;
+import umc.th.juinjang.domain.checklist.model.ChecklistQuestionCategory;
+import umc.th.juinjang.domain.checklist.model.ChecklistQuestionShort;
+import umc.th.juinjang.domain.checklist.model.ChecklistQuestionType;
+import umc.th.juinjang.domain.checklist.repository.ChecklistAnswerRepository;
+import umc.th.juinjang.domain.checklist.repository.ChecklistQuestionRepository;
+import umc.th.juinjang.domain.limjang.model.Limjang;
+import umc.th.juinjang.domain.report.model.Report;
+import umc.th.juinjang.domain.report.repository.ReportRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChecklistCommandServiceV2 {
+	private final ChecklistAnswerRepository checklistAnswerRepository;
+	private final ChecklistQuestionRepository checklistQuestionRepository;
+	private final NoteFinder noteFinder;
+	private final NoteQueryServiceV2 noteQueryService;
+	private final ReportRepository reportRepository;
+	private final NoteUpdater noteUpdater;
+
+	@Transactional
+	public ChecklistAnswerAndReportResponseDTO saveChecklistAnswerList(Long limjangId,
+		List<ChecklistAnswerRequestDTO.AnswerDto> answerDtoList) {
+		Limjang note = noteFinder.getNoteByIdWhereDeletedIsFalse(limjangId);
+		if (!checklistAnswerRepository.findChecklistAnswerByLimjangId(note).isEmpty()) {
+			checklistAnswerRepository.deleteAllByLimjangId(note);
+			checklistAnswerRepository.flush();
+		}
+
+		List<ChecklistAnswer> answerList = createAnswerList(note, answerDtoList);
+		answerList = checklistAnswerRepository.saveAll(answerList);
+
+		//ChecklistQuestion의 Category로 그룹을 지어줌
+		//categorizedAnswers는 ChecklistQuestionCategory를 키로, 해당 카테고리에 해당하는 ChecklistAnswer 리스트를 값으로 가지는 Map
+		Map<ChecklistQuestionCategory, List<ChecklistAnswer>> categorizedAnswers = answerList.stream()
+			.collect(Collectors.groupingBy(answer -> answer.getQuestionId().getCategory()));
+
+		Report report = findOrCreateReport(note);
+		reportRepository.save(calculateAndSetCategoryRates(report, categorizedAnswers));
+
+		ChecklistConditionResponse checklistConditionResponse = noteQueryService.checkLimjangChecklistSatisfaction(
+			note.getLimjangId());
+		try {
+			note.updateSharable(checklistConditionResponse.isTotalSatisfied());
+			noteUpdater.save(note);
+		} catch (Exception e) {
+			throw new LimjangHandler(ErrorStatus.LIMJANG_UPDATE_FAILED);
+		}
+
+		return ChecklistAnswerAndReportConverter.toDto(answerList, report, note);
+	}
+
+	private List<ChecklistAnswer> createAnswerList(Limjang limjang,
+		List<ChecklistAnswerRequestDTO.AnswerDto> answerDtoList) {
+		return answerDtoList.stream()
+			.map(dto -> {
+				ChecklistQuestionShort question = checklistQuestionRepository.findById(dto.getQuestionId())
+					.orElseThrow(() -> new ChecklistHandler(ErrorStatus.CHECKLIST_NOTFOUND_ERROR));
+
+				return ChecklistAnswer.builder()
+					.questionId(question)
+					.limjangId(limjang)
+					.answer(dto.getAnswer())
+					.build();
+			})
+			.collect(Collectors.toList());
+	}
+
+	private Report findOrCreateReport(Limjang limjang) {
+		return reportRepository.findByLimjangId(limjang)
+			.orElseGet(() -> Report.builder()
+				.limjangId(limjang)
+				.build());
+	}
+
+	private Report calculateAndSetCategoryRates(Report report,
+		Map<ChecklistQuestionCategory, List<ChecklistAnswer>> categorizedAnswers) {
+		float totalRate = 0F;
+
+		//데드라인 : {answer 모음들}, 입지여건 : {answer 모음들}, 공용공간 ~~
+
+		ChecklistQuestionCategory[] categories = ChecklistQuestionCategory.values();
+		int categoryCount = categories.length;
+		for (ChecklistQuestionCategory category : categories) {
+			if (category == ChecklistQuestionCategory.DEADLINE) {
+				categoryCount -= 1;
+				continue;
+			}
+			List<ChecklistAnswer> answers = categorizedAnswers.get(category);
+			Float categoryRate = calculateAverage(answers);
+
+			if (categoryRate == null) {
+				categoryRate = 0F;
+			}
+			String keyword = setRandomKeyword(categoryRate);
+
+			System.out.println(categoryRate);
+			System.out.println(keyword);
+			if (categoryRate == 0f) {
+				categoryCount -= 1;
+			}
+			switch (category) {
+				case INDOOR:
+					report.setIndoorRate(categoryRate);
+					report.setIndoorKeyword(keyword);
+					break;
+				case PUBLIC_SPACE:
+					report.setPublicSpaceRate(categoryRate);
+					report.setPublicSpaceKeyword(keyword);
+					break;
+				case LOCATION_CONDITION:
+					report.setLocationConditionsRate(categoryRate);
+					report.setLocationConditionsKeyword(keyword);
+					break;
+
+			}
+
+			totalRate += categoryRate;
+		}
+		if (categoryCount <= 0) {
+			report.setTotalRate(totalRate);
+		} else {
+			report.setTotalRate(totalRate / categoryCount);
+		}
+		return report;
+	}
+
+	private Float calculateAverage(List<ChecklistAnswer> answers) {
+		if (answers == null || answers.isEmpty()) {
+			return 0f;
+		}
+		Float total = 0f;
+		int count = 0;
+		for (ChecklistAnswer answer : answers) {
+			if (answer.getQuestionId().getAnswerType() == ChecklistQuestionType.SCORE) {
+				System.out.println(
+					"questionId : " + answer.getQuestionId().getQuestionId() + " answerType : " + answer.getQuestionId()
+						.getAnswerType());
+				total += Float.parseFloat(answer.getAnswer());
+				count++;
+			}
+		}
+		if (count == 0) {
+			return 0f;
+		}
+		return total / count;
+	}
+
+	public String setRandomKeyword(Float rate) {
+
+		String[] oneToTwo = {"불안한", "불안정한", "불쾌한"};
+		String[] twoToThree = {"평균적인", "보통의", "나쁘지 않은"};
+		String[] threeToFour = {"좋은", "좋은 편인", "훌륭한", "쾌적한"};
+		String[] fourToFive = {"최상의", "최고의", "상당히 좋은", "상당히 쾌적한"};
+		String defaultKeyword = "아직 미평가된";
+
+		Random random = new Random();
+
+		if (rate >= 1 && rate < 2) {
+			return oneToTwo[random.nextInt(oneToTwo.length)];
+		} else if (rate >= 2 && rate < 3) {
+			return twoToThree[random.nextInt(twoToThree.length)];
+		} else if (rate >= 3 && rate < 4) {
+			return threeToFour[random.nextInt(threeToFour.length)];
+		} else if (rate >= 4 && rate <= 5) {
+			return fourToFive[random.nextInt(fourToFive.length)];
+		}
+
+		return defaultKeyword;
+
+	}
+}

--- a/src/main/java/umc/th/juinjang/api/note/shared/controller/SharedNoteController.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/controller/SharedNoteController.java
@@ -55,6 +55,7 @@ public class SharedNoteController {
 		@RequestBody SharedNotePostRequest request) {
 		sharedNoteCommandService.createSharedNote(member, noteId, request);
 		return ApiResponse.onSuccess(null);
+	}
 
 	@Operation(summary = "공유 노트 둘러보기 API")
 	@GetMapping("/explore")

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
@@ -3,11 +3,14 @@ package umc.th.juinjang.api.note.shared.service;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.List;
+
 import org.hibernate.exception.LockAcquisitionException;
 import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import com.google.cloud.vision.v1.Likelihood;
+
 import jakarta.persistence.PessimisticLockException;
 import lombok.RequiredArgsConstructor;
 import umc.th.juinjang.api.limjang.service.NoteFinder;
@@ -29,7 +32,7 @@ import umc.th.juinjang.domain.pencil.purchased.model.PurchasedPencil;
 import umc.th.juinjang.domain.pencil.used.model.UsedPencil;
 import umc.th.juinjang.domain.pencil.used.model.Usedtype;
 import umc.th.juinjang.domain.pencilaccount.model.PencilAccount;
-import umc.th.juinjang.safeSearch.SafeSearchClient;
+import umc.th.juinjang.external.safeSearch.SafeSearchClient;
 
 @Service
 @RequiredArgsConstructor
@@ -45,7 +48,6 @@ public class SharedNoteCommandService {
 	private final SafeSearchClient safeSearchClient;
 	private final NoteUpdater noteUpdater;
 	private final PurchasedPencilUpdater purchasedPencilUpdater;
-
 
 	@Transactional
 	public void createSharedNotePurchase(Member buyer, Long sharedNoteId) {
@@ -93,8 +95,8 @@ public class SharedNoteCommandService {
 
 	private AcquiredPencil createAcquiredPencil(Long sharedNoteId, Member seller, Long price, AcquiredType type) {
 		return AcquiredPencil.create(seller, "", sharedNoteId, price, false, type);
-  }
-  
+	}
+
 	private void consumePurchasedPencils(Member buyer, long unpaidPencil) {
 		List<PurchasedPencil> purchasedPencils = purchasedPencilUpdater.findByMemberAndDeliverySuccessRemainQuantityGreaterThanOrderByCreatedAtAsc(
 			buyer, 0L);
@@ -116,7 +118,6 @@ public class SharedNoteCommandService {
 			throw new SharedNoteHandler(ErrorStatus.SHAREDNOTE_NOT_ENOUGH_PENCIL);
 		}
 	}
-
 
 	private UsedPencil createUsedPencil(Member member, Long sharedNoteId, SharedNote sharedNote,
 		PencilAccount buyerAccount) {

--- a/src/main/java/umc/th/juinjang/common/code/status/ErrorStatus.java
+++ b/src/main/java/umc/th/juinjang/common/code/status/ErrorStatus.java
@@ -53,6 +53,7 @@ public enum ErrorStatus implements BaseErrorCode {
 		"요청한 임장 게시글이 모두 삭제되지 않아 삭제가 취소되었습니다. 다시 시도하거나 백엔드 팀에 문의바랍니다."),
 	LIMJANG_UPDATE_PRICETYPE_ERROR(HttpStatus.BAD_REQUEST, "LIMJANG4007", "가격유형 입력값이 잘못되었습니다. 다시 확인해주세요."),
 	LIMJANG_REQUEST_SORT_ERROR(HttpStatus.BAD_REQUEST, "LIMJANG4008", "요청한 정렬 방식이 지정되지 않은 값입니다. 다시 확인해주세요."),
+	LIMJANG_UPDATE_FAILED(HttpStatus.BAD_REQUEST, "LIMJANG4009", "요청한 임장 업데이트가 정상적으로 진행되지 않았습니다. 백엔드 팀에 문의 바랍니다."),
 
 	// LimjangPrice Error
 	LIMJANGPRICE_NOTFOUND_ERROR(HttpStatus.BAD_REQUEST, "LIMJANGPRICE4000", "해당 임장가격 레코드가 존재하지 않습니다."),
@@ -110,8 +111,8 @@ public enum ErrorStatus implements BaseErrorCode {
 	SHAREDNOTE_DEADLOCK(HttpStatus.LOCKED, "SHAREDNOTE4003", "잠시 후 다시 시도해주세요. 현재 다른 요청이 처리 중입니다."),
 	SHAREDNOTE_TYPE_ERROR(HttpStatus.BAD_REQUEST, "SHAREDNOTE4004", "유효하지 않은 마이 노트 요청 타입입니다."),
 	SHARED_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "SAHREDNOTE4005", "공유가 금지된 노트입니다."),
-	SHAREDNOTE_DELETED_RECENTLY(HttpStatus.BAD_REQUEST, "SHAREDNOTE4006", "삭제한지 6개월이 지나지 않아 다시 공유할 수 없습니다."),	
-  SHAREDNOTE_ALREADY_EXISTS(HttpStatus.CONFLICT, "SHAREDNOTE4007", "이미 공유된 노트입니다."),
+	SHAREDNOTE_DELETED_RECENTLY(HttpStatus.BAD_REQUEST, "SHAREDNOTE4006", "삭제한지 6개월이 지나지 않아 다시 공유할 수 없습니다."),
+	SHAREDNOTE_ALREADY_EXISTS(HttpStatus.CONFLICT, "SHAREDNOTE4007", "이미 공유된 노트입니다."),
 
 	// LikedNote
 	LIKEDNOTE_CONFLICT(HttpStatus.CONFLICT, "LIKEDNOTE4000", "이미 좋아요한 노트입니다"),

--- a/src/main/java/umc/th/juinjang/domain/limjang/model/Limjang.java
+++ b/src/main/java/umc/th/juinjang/domain/limjang/model/Limjang.java
@@ -143,6 +143,7 @@ public class Limjang extends BaseEntity {
 
 	public void updateRewardPencil(Integer rewardPencil) {
 		this.rewardPencil = rewardPencil;
+	}
 
 	public void updateSharable(boolean state) {
 		this.isSharable = state;

--- a/src/main/java/umc/th/juinjang/external/safeSearch/SafeSearchClient.java
+++ b/src/main/java/umc/th/juinjang/external/safeSearch/SafeSearchClient.java
@@ -1,4 +1,4 @@
-package umc.th.juinjang.safeSearch;
+package umc.th.juinjang.external.safeSearch;
 
 import java.io.IOException;
 import java.util.Collections;


### PR DESCRIPTION
## 작업내용
checklist 답변 생성 및 수정시 isSharable 업데이트 추가

## 상세설명_ & 캡쳐
![image](https://github.com/user-attachments/assets/f963d4f6-ff5b-4cb0-83e2-c712f956d7d5)
isSharable 필드가 새로 생겼습니다. (테스트때문에 현재 DEV DB에는 반영되어 있습니다.)

![image](https://github.com/user-attachments/assets/af2205fb-a3ac-407d-bca6-86a57660c6dd)
기존 메서드는 그대로 두고 ChecklistV2Controller에 새로 추가하였습니다.

![image](https://github.com/user-attachments/assets/3215556e-2b40-426d-858f-a5408e2d39cd)
Condition 체크해주는 service 코드를 그대로 활용하여 업데이트하도록 구현하였습니다.
(이후 service 코드 내 리팩터링을 통해 계산만 담당하는 메서드 따로 분리하겠습니다 😢 )