### PR TITLE
[feat/#335] SharedNote 구매시 리뷰 + 체크리스트 보이도록, 구매하지 않았을 시 체크리스트만 보이도록 하는 조회 API

### DIFF
--- a/src/main/java/umc/th/juinjang/api/note/shared/controller/SharedNoteController.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/controller/SharedNoteController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import umc.th.juinjang.api.dto.ApiResponse;
 import umc.th.juinjang.api.note.shared.service.SharedNoteCommandService;
 import umc.th.juinjang.api.note.shared.service.SharedNoteQueryService;
+import umc.th.juinjang.api.note.shared.service.response.SharedNoteCheckListAndReviewResponse;
 import umc.th.juinjang.api.note.shared.service.response.SharedNoteExploreGetResponse;
 import umc.th.juinjang.api.note.shared.service.response.SharedNoteGetResponse;
 import umc.th.juinjang.api.note.shared.service.response.UserSharedNotesGetResponse;
@@ -71,5 +72,14 @@ public class SharedNoteController {
 	) {
 		return ApiResponse.onSuccess(
 			sharedNoteQueryService.findUserSharedNotes(member, noteType, propertyType, priceType, keyword));
+	}
+
+	@Operation(summary = "체크리스트 및 상세 후기 API")
+	@GetMapping("shared-note/{sharedNoteId}/checklist")
+	public ApiResponse<SharedNoteCheckListAndReviewResponse> findChecklistAndReview(
+		@AuthenticationPrincipal Member member,
+		@PathVariable("sharedNoteId") Long sharedNoteId) {
+		return ApiResponse.onSuccess(
+			sharedNoteQueryService.findChecklistAndReview(member, sharedNoteId));
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteQueryService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteQueryService.java
@@ -5,9 +5,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -18,17 +16,19 @@ import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.xml.sax.ErrorHandler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import umc.th.juinjang.api.checklist.service.ChecklistAnswerFinder;
+import umc.th.juinjang.api.checklist.service.response.ChecklistAnswerResponseDTO;
 import umc.th.juinjang.api.note.liked.service.LikedNoteFinder;
 import umc.th.juinjang.api.note.shared.controller.ExploreSortType;
 import umc.th.juinjang.api.note.shared.controller.NoteType;
+import umc.th.juinjang.api.note.shared.service.response.SharedNoteCheckListAndReviewResponse;
 import umc.th.juinjang.api.note.shared.service.response.SharedNoteExploreGetResponse;
+import umc.th.juinjang.api.note.shared.service.response.SharedNoteGetResponse;
 import umc.th.juinjang.api.note.shared.service.response.UserSharedNotesGetResponse;
 import umc.th.juinjang.api.pencil.service.UsedPencilFinder;
-import umc.th.juinjang.api.note.shared.service.response.SharedNoteGetResponse;
 import umc.th.juinjang.common.code.status.ErrorStatus;
 import umc.th.juinjang.common.exception.handler.SharedNoteHandler;
 import umc.th.juinjang.common.redis.RedisKeyFactory;
@@ -48,6 +48,7 @@ public class SharedNoteQueryService {
 	private final UsedPencilFinder usedPencilFinder;
 	private final SharedNoteFinder sharedNoteFinder;
 	private final LikedNoteFinder likedNoteFinder;
+	private final ChecklistAnswerFinder checklistAnswerFinder;
 	private final RedisTemplate<String, String> redisTemplate;
 
 	@Transactional(readOnly = true)
@@ -214,11 +215,23 @@ public class SharedNoteQueryService {
 		List<LikedNote> userLikedNotes = likedNoteFinder.findAllByMemberAndDynamic(member, propertyType,
 			priceType, keyword);
 		List<SharedNote> sharedNotes = userLikedNotes.stream().map(LikedNote::getSharedNote).toList();
-		
+
 		Set<Long> purchasedIds = new HashSet<>(usedPencilFinder.findByMemberInSharedNoteIdsAndTypeIsOwned(member,
 			sharedNotes.stream().map(SharedNote::getSharedNoteId).toList()));
 		Map<Long, Long> viewcountMap = mapIdsAndViewcount(sharedNotes);
 
 		return UserSharedNotesGetResponse.ofLiked(sharedNotes, purchasedIds, viewcountMap);
+	}
+
+	@Transactional(readOnly = true)
+	public SharedNoteCheckListAndReviewResponse findChecklistAndReview(Member member, Long sharedNoteId) {
+		SharedNote sharedNote = sharedNoteFinder.findByIdWithNoteAndAddress(sharedNoteId);
+		Limjang limjang = sharedNote.getLimjang();
+		List<ChecklistAnswerResponseDTO.AnswerDto> answers = checklistAnswerFinder.findByLimjangId(
+			limjang.getLimjangId());
+		boolean isOwned = usedPencilFinder.existsByMemberAndSharedNoteId(member, sharedNoteId);
+		// 구매했다면 review 포함, 아니면 null
+		String review = isOwned ? sharedNote.getReview() : null;
+		return new SharedNoteCheckListAndReviewResponse(review, answers);
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/response/SharedNoteCheckListAndReviewResponse.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/response/SharedNoteCheckListAndReviewResponse.java
@@ -1,0 +1,11 @@
+package umc.th.juinjang.api.note.shared.service.response;
+
+import java.util.List;
+
+import umc.th.juinjang.api.checklist.service.response.ChecklistAnswerResponseDTO;
+
+public record SharedNoteCheckListAndReviewResponse(
+	String review,
+	List<ChecklistAnswerResponseDTO.AnswerDto> checklistAnswers
+) {
+}


### PR DESCRIPTION
## 작업내용
SharedNote 구매시 리뷰 + 체크리스트 보이도록, 구매하지 않았을 시 체크리스트만 보이도록 하는 조회 API

## 상세설명_ & 캡쳐
![image](https://github.com/user-attachments/assets/4a8a59eb-f340-4500-bd5d-5940b97e0a8e)
구매시 review 포함되어 나오고,

![image](https://github.com/user-attachments/assets/912ff9e1-6950-4071-9028-23856ca5342b)
구매하지 않았을 시 review가 null로 나오도록 구성하였습니다!

![image](https://github.com/user-attachments/assets/285f7870-7944-4141-8442-d130ee21427e)
이미 구현해주신 메서드 사용하여 간단하게 구현하였습니다.