### PR TITLE
[refactor/#384] 공유된 임장 구입시 노트 가격 서버에서 처리

### DIFF
--- a/src/main/java/umc/th/juinjang/api/note/shared/controller/request/SharedNotePostRequest.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/controller/request/SharedNotePostRequest.java
@@ -9,7 +9,6 @@ public record SharedNotePostRequest(
 	@NotNull Boolean isImageShared,
 	@NotNull Integer year,
 	@NotNull Integer month,
-	@NotBlank String period,
-	@NotNull Long price
+	@NotBlank String period
 ) {
 }

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
@@ -128,6 +128,7 @@ public class SharedNoteCommandService {
 	@Transactional
 	public void createSharedNote(Member member, Long noteId, SharedNotePostRequest request) {
 		Integer rewardPencilCount = 0;
+		Integer price = 0;
 
 		Optional<SharedNote> latestSharedNote = sharedNoteFinder.findLatestByLimjangId(noteId);
 		if (latestSharedNote.isPresent()) {
@@ -160,16 +161,19 @@ public class SharedNoteCommandService {
 				}
 			}
 			rewardPencilCount = 7;
+			price = 10;
 		}
 		//사진 공유 안함 체크 or 임장노트에 사진이 없으면
 		else if (request.isImageShared() == Boolean.TRUE || limjang.getImageList().isEmpty()) {
 			rewardPencilCount = 2;
+			price = 5;
 		}
 		limjang.updateRewardPencil(rewardPencilCount);
 		noteUpdater.save(limjang);
 
 		//저장
 		SharedNote sharedNote = SharedNote.toSharedNote(member, limjang, request);
+		sharedNote.updatePrice(price);
 		sharedNoteUpdater.save(sharedNote);
 
 		//사용자 지갑에 rewardPencil만큼 업데이트

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
@@ -128,7 +128,7 @@ public class SharedNoteCommandService {
 	@Transactional
 	public void createSharedNote(Member member, Long noteId, SharedNotePostRequest request) {
 		Integer rewardPencilCount = 0;
-		Integer price = 0;
+		Long price = 0L;
 
 		Optional<SharedNote> latestSharedNote = sharedNoteFinder.findLatestByLimjangId(noteId);
 		if (latestSharedNote.isPresent()) {
@@ -161,12 +161,12 @@ public class SharedNoteCommandService {
 				}
 			}
 			rewardPencilCount = 7;
-			price = 10;
+			price = 10L;
 		}
 		//사진 공유 안함 체크 or 임장노트에 사진이 없으면
 		else if (request.isImageShared() == Boolean.TRUE || limjang.getImageList().isEmpty()) {
 			rewardPencilCount = 2;
-			price = 5;
+			price = 5L;
 		}
 		limjang.updateRewardPencil(rewardPencilCount);
 		noteUpdater.save(limjang);

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteQueryService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteQueryService.java
@@ -45,7 +45,6 @@ public class SharedNoteQueryService {
 	private final SharedNoteFinder sharedNoteFinder;
 	private final LikedNoteFinder likedNoteFinder;
 	private final ChecklistAnswerFinder checklistAnswerFinder;
-	private final RedisTemplate<String, String> redisTemplate;
 	private final ViewCountService viewCountService;
 	private final ApplicationRewardViewCountPublisherAdapter applicationRewardViewCountPublisherAdapter;
 

--- a/src/main/java/umc/th/juinjang/domain/note/shared/model/SharedNote.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/model/SharedNote.java
@@ -55,7 +55,7 @@ public class SharedNote extends BaseEntity {
 	private String review;
 
 	@Comment("임장 가격")
-	private Long price;
+	private Integer price;
 
 	private Long likeCount;
 
@@ -80,9 +80,12 @@ public class SharedNote extends BaseEntity {
 			.year(dto.year())
 			.month(dto.month())
 			.period(dto.period())
-			.price(dto.price())
 			.isImageShared(dto.isImageShared())
 			.build();
+	}
+
+	public void updatePrice(int price) {
+		this.price = price;
 	}
 }
 

--- a/src/main/java/umc/th/juinjang/domain/note/shared/model/SharedNote.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/model/SharedNote.java
@@ -55,7 +55,7 @@ public class SharedNote extends BaseEntity {
 	private String review;
 
 	@Comment("임장 가격")
-	private Integer price;
+	private Long price;
 
 	private Long likeCount;
 
@@ -84,7 +84,7 @@ public class SharedNote extends BaseEntity {
 			.build();
 	}
 
-	public void updatePrice(int price) {
+	public void updatePrice(long price) {
 		this.price = price;
 	}
 }


### PR DESCRIPTION
## 작업내용
공유된 임장 구입시 노트 가격 서버에서 처리하도록 로직 변경

## 상세설명_ & 캡쳐
![image](https://github.com/user-attachments/assets/5ebda943-520d-4666-bef7-d38a79b27eb7)
price를 클라이언트측에서 받지 않고 로직 내부에서 판단하도록 변경하였습니다.
사진 공유시 10, 사진 공유X시 5개로 설정하고 price 업데이트할 수 있도록 하였습니다.