### PR TITLE
[feat/#390] 임장 상세 API에서 공유된 임장인지 판별하는 필드값 추가

### DIFF
--- a/src/main/java/umc/th/juinjang/api/limjang/service/NoteQueryServiceV2.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/service/NoteQueryServiceV2.java
@@ -18,6 +18,7 @@ import umc.th.juinjang.api.limjang.service.response.ChecklistConditionResponse;
 import umc.th.juinjang.api.limjang.service.response.UserNoteGetResponse;
 import umc.th.juinjang.api.limjang.service.response.UserNotesGetResponse;
 import umc.th.juinjang.api.limjang.service.response.UserNotesShareableGetResponse;
+import umc.th.juinjang.api.note.shared.service.SharedNoteFinder;
 import umc.th.juinjang.api.scrap.service.ScarpFinder;
 import umc.th.juinjang.domain.checklist.model.ChecklistAnswer;
 import umc.th.juinjang.domain.checklist.model.ChecklistQuestionCategory;
@@ -34,6 +35,7 @@ public class NoteQueryServiceV2 {
 	private final ScarpFinder scarpFinder;
 	private final ImageFinder imageFinder;
 	private final ChecklistAnswerFinder checklistAnswerFinder;
+	private final SharedNoteFinder sharedNoteFinder;
 
 	@Transactional(readOnly = true)
 	public UserNotesGetResponse findUsersNotes(Member member, LimjangSortOptions sortOptions) {
@@ -76,7 +78,9 @@ public class NoteQueryServiceV2 {
 
 	@Transactional(readOnly = true)
 	public UserNoteGetResponse findNote(Long noteId) {
-		return UserNoteGetResponse.of(noteFinder.getNoteByIdWithAddressAndNotePriceWhereDeletedIsFalse(noteId));
+		Limjang note = noteFinder.getNoteByIdWithAddressAndNotePriceWhereDeletedIsFalse(noteId);
+		boolean isShared = sharedNoteFinder.existsByDeletedAtIsNullAndLimjang(note);
+		return UserNoteGetResponse.of(isShared, note);
 	}
 
 	public ChecklistConditionResponse checkLimjangChecklistSatisfaction(Long limjangId) {

--- a/src/main/java/umc/th/juinjang/api/limjang/service/response/UserNoteGetResponse.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/service/response/UserNoteGetResponse.java
@@ -10,6 +10,7 @@ import umc.th.juinjang.domain.limjang.model.LimjangPropertyType;
 import umc.th.juinjang.domain.limjang.model.LimjangPurpose;
 
 public record UserNoteGetResponse(
+	boolean isShared,
 	LimjangPurpose purposeType,
 	LimjangPropertyType propertyType,
 	LimjangPriceType priceType,
@@ -22,8 +23,9 @@ public record UserNoteGetResponse(
 	String floor,
 	Integer pyong
 ) {
-	public static UserNoteGetResponse of(Limjang note) {
+	public static UserNoteGetResponse of(boolean isShared, Limjang note) {
 		return new UserNoteGetResponse(
+			isShared,
 			note.getPurpose(),
 			note.getPropertyType(),
 			note.getPriceType(),

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteFinder.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteFinder.java
@@ -14,6 +14,7 @@ import umc.th.juinjang.api.note.shared.controller.request.ExploreSortType;
 import umc.th.juinjang.api.note.shared.controller.request.NoteType;
 import umc.th.juinjang.common.code.status.ErrorStatus;
 import umc.th.juinjang.common.exception.handler.SharedNoteHandler;
+import umc.th.juinjang.domain.limjang.model.Limjang;
 import umc.th.juinjang.domain.limjang.model.LimjangPriceType;
 import umc.th.juinjang.domain.limjang.model.LimjangPropertyType;
 import umc.th.juinjang.domain.member.model.Member;
@@ -44,11 +45,10 @@ public class SharedNoteFinder {
 		return sharedNoteRepository.getLikeCountById(id);
 	}
 
-
 	public Optional<SharedNote> findLatestByLimjangId(Long limjangId) {
 		return sharedNoteRepository.findLatestByLimjangId(limjangId);
-  }
-  
+	}
+
 	Page<SharedNote> findSharedNoteInExployer(List<String> code, ExploreSortType sort,
 		LimjangPropertyType propertyType, LimjangPriceType priceType, String keyword, Pageable pageable) {
 		return sharedNoteRepository.findSharedNoteInExployer(code, sort, propertyType, priceType,
@@ -70,5 +70,9 @@ public class SharedNoteFinder {
 
 	public Long findViewCountById(Long id) {
 		return sharedNoteRepository.findViewCountById(id);
+	}
+
+	public boolean existsByDeletedAtIsNullAndLimjang(Limjang limjang) {
+		return sharedNoteRepository.existsByDeletedAtIsNullAndLimjang(limjang);
 	}
 }

--- a/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import umc.th.juinjang.domain.limjang.model.Limjang;
 import umc.th.juinjang.domain.note.shared.model.SharedNote;
 
 public interface SharedNoteRepository extends JpaRepository<SharedNote, Long>, SharedNoteQueryDSLRepository {
@@ -38,6 +39,8 @@ public interface SharedNoteRepository extends JpaRepository<SharedNote, Long>, S
 
 	@Query("SELECT s.viewCount FROM SharedNote s WHERE s.sharedNoteId = :id")
 	Long findViewCountById(@Param("id") Long id);
-	
+
 	Optional<SharedNote> findBySharedNoteIdAndDeletedAtIsNull(Long id);
+
+	boolean existsByDeletedAtIsNullAndLimjang(Limjang limjang);
 }


### PR DESCRIPTION
## 작업내용

임장 상세 API에서 공유된 임장인지 판별하는 필드값 추가

## 상세설명_ & 캡쳐

- 프론트분들 요청에 따라 response body에 공유된 임장인지 판별하는 값을 추가했습니다. 
- 아래와 같은 JPA 쿼리 메소드를 추가했습니다. 
- SharedNote에서 deleteAt과 limjang_id를 통해 공유된 임장인지 판별합니다. 

`boolean existsByDeletedAtIsNullAndLimjang(Limjang limjang);
`

### 발생 쿼리

```sql
select
   sn1_0.shared_note_id
from
   shared_note sn1_0
where
  fetch 
    sn1_0.deleted_at is null and sn1_0.limjang_id=?
  first ? rows only
```