### PR TITLE
[fix/#389] 공유된 임장은 필터링되도록 Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ out/
 /src/main/resources/*.json
 /src/main/generated/*
 /src/test/java/resources/application-*.yml
+
+src/main/resources/keys
+src/main/resources/certs

--- a/src/main/java/umc/th/juinjang/api/limjang/service/NoteFinder.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/service/NoteFinder.java
@@ -32,7 +32,7 @@ public class NoteFinder {
 			.orElseThrow(() -> new LimjangHandler(ErrorStatus.LIMJANG_NOTFOUND_ERROR));
 	}
 
-	protected List<Limjang> getAllByMemberWithAddressAndNotePriceWhereRewardPencilIsNotNullAndDeletedIsFalse(
+	protected List<Limjang> getAllByMemberWithAddressAndNotePriceWhereIsSharableIsTrueAndDeletedIsFalse(
 		Member member) {
 		return limjangRepository.findAllByMemberWithAddressAndNotePriceWhereIsSharableIsTrueAndDeletedIsFalse(
 			member);

--- a/src/main/java/umc/th/juinjang/api/limjang/service/NoteQueryServiceV2.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/service/NoteQueryServiceV2.java
@@ -60,12 +60,21 @@ public class NoteQueryServiceV2 {
 
 	@Transactional(readOnly = true)
 	public UserNotesShareableGetResponse findNotesShareable(Member member) {
-		List<Limjang> notes = noteFinder.getAllByMemberWithAddressAndNotePriceWhereRewardPencilIsNotNullAndDeletedIsFalse(
+		List<Limjang> filteredSharedNotes = findUnsharedSharableNotes(member);
+		List<Image> imageList = imageFinder.findAllFirstCreatedImagePerNote(filteredSharedNotes);
+
+		return UserNotesShareableGetResponse.of(filteredSharedNotes, mapToNoteIdAndImageId(imageList),
+			mapToNoteScrapStatus(filteredSharedNotes));
+	}
+
+	private List<Limjang> findUnsharedSharableNotes(Member member) {
+		List<Limjang> notes = noteFinder.getAllByMemberWithAddressAndNotePriceWhereIsSharableIsTrueAndDeletedIsFalse(
 			member);
+		Set<Long> sharedNote = sharedNoteFinder.findAllIdByDeletedAtIsNullAndLimjang(notes);
 
-		List<Image> imageList = imageFinder.findAllFirstCreatedImagePerNote(notes);
-
-		return UserNotesShareableGetResponse.of(notes, mapToNoteIdAndImageId(imageList), mapToNoteScrapStatus(notes));
+		return notes.stream()
+			.filter(note -> !sharedNote.contains(note.getLimjangId()))
+			.toList();
 	}
 
 	private Map<Long, String> mapToNoteIdAndImageId(List<Image> imageList) {

--- a/src/main/java/umc/th/juinjang/api/limjang/service/NoteQueryServiceV2.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/service/NoteQueryServiceV2.java
@@ -70,10 +70,10 @@ public class NoteQueryServiceV2 {
 	private List<Limjang> findUnsharedSharableNotes(Member member) {
 		List<Limjang> notes = noteFinder.getAllByMemberWithAddressAndNotePriceWhereIsSharableIsTrueAndDeletedIsFalse(
 			member);
-		Set<Long> sharedNote = sharedNoteFinder.findAllIdByDeletedAtIsNullAndLimjang(notes);
+		Set<Long> noteIdInSharedNotes = sharedNoteFinder.findLimjangIdsByDeletedAtIsNullAndLimjang(notes);
 
 		return notes.stream()
-			.filter(note -> !sharedNote.contains(note.getLimjangId()))
+			.filter(note -> !noteIdInSharedNotes.contains(note.getLimjangId()))
 			.toList();
 	}
 

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteFinder.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteFinder.java
@@ -3,6 +3,7 @@ package umc.th.juinjang.api.note.shared.service;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
@@ -52,7 +53,7 @@ public class SharedNoteFinder {
 
 	public Optional<SharedNote> findLatestByLimjangId(Long limjangId) {
 		return sharedNoteRepository.findLatestByLimjangId(limjangId);
-  }
+	}
 
 	Page<SharedNote> findSharedNoteInExployer(List<String> code, ExploreSortType sort,
 		LimjangPropertyType propertyType, LimjangPriceType priceType, String keyword, Pageable pageable) {
@@ -79,5 +80,9 @@ public class SharedNoteFinder {
 
 	public boolean existsByDeletedAtIsNullAndLimjang(Limjang limjang) {
 		return sharedNoteRepository.existsByDeletedAtIsNullAndLimjang(limjang);
+	}
+
+	public Set<Long> findAllIdByDeletedAtIsNullAndLimjang(List<Limjang> notes) {
+		return sharedNoteRepository.findAllIdByDeletedAtIsNullAndLimjang(notes);
 	}
 }

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteFinder.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteFinder.java
@@ -82,7 +82,7 @@ public class SharedNoteFinder {
 		return sharedNoteRepository.existsByDeletedAtIsNullAndLimjang(limjang);
 	}
 
-	public Set<Long> findAllIdByDeletedAtIsNullAndLimjang(List<Limjang> notes) {
-		return sharedNoteRepository.findAllIdByDeletedAtIsNullAndLimjang(notes);
+	public Set<Long> findLimjangIdsByDeletedAtIsNullAndLimjang(List<Limjang> notes) {
+		return sharedNoteRepository.findLimjangIdsByDeletedAtIsNullAndLimjang(notes);
 	}
 }

--- a/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteRepository.java
@@ -48,6 +48,6 @@ public interface SharedNoteRepository extends JpaRepository<SharedNote, Long>, S
 
 	boolean existsByDeletedAtIsNullAndLimjang(Limjang limjang);
 
-	@Query("SELECT s.sharedNoteId FROM SharedNote s WHERE s.limjang in :limjangs AND s.deletedAt is null ")
-	Set<Long> findAllIdByDeletedAtIsNullAndLimjang(@Param("limjangs") List<Limjang> limjangs);
+	@Query("SELECT s.limjang.limjangId FROM SharedNote s WHERE s.limjang in :limjangs AND s.deletedAt is null ")
+	Set<Long> findLimjangIdsByDeletedAtIsNullAndLimjang(@Param("limjangs") List<Limjang> limjangs);
 }

--- a/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteRepository.java
@@ -2,6 +2,7 @@ package umc.th.juinjang.domain.note.shared.repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -46,4 +47,7 @@ public interface SharedNoteRepository extends JpaRepository<SharedNote, Long>, S
 	Optional<SharedNote> findBySharedNoteIdAndDeletedAtIsNull(Long id);
 
 	boolean existsByDeletedAtIsNullAndLimjang(Limjang limjang);
+
+	@Query("SELECT s.sharedNoteId FROM SharedNote s WHERE s.limjang in :limjangs AND s.deletedAt is null ")
+	Set<Long> findAllIdByDeletedAtIsNullAndLimjang(@Param("limjangs") List<Limjang> limjangs);
 }


### PR DESCRIPTION
## 작업내용

공유된 임장은 필터링되도록 Fix

## 상세설명_ & 캡쳐

- 공유할 임장 리스트 return 시 이미 공유된 임장은 필터링되도록 구현

```java
	private List<Limjang> findUnsharedSharableNotes(Member member) {
		List<Limjang> notes = noteFinder.getAllByMemberWithAddressAndNotePriceWhereIsSharableIsTrueAndDeletedIsFalse(
			member);
		Set<Long> sharedNote = sharedNoteFinder.findAllIdByDeletedAtIsNullAndLimjang(notes);

		return notes.stream()
			.filter(note -> !sharedNote.contains(note.getLimjangId()))
			.toList();
	}
```

```java
	@Query("SELECT s.sharedNoteId FROM SharedNote s WHERE s.limjang in :limjangs AND s.deletedAt is null ")
	Set<Long> findAllIdByDeletedAtIsNullAndLimjang(@Param("limjangs") List<Limjang> limjangs);
```