### PR TITLE
[fix/#398] 임장 나누기 화면에서 bcode null일 경우 나오지 않도록 쿼리 fix

### DIFF
--- a/src/main/java/umc/th/juinjang/api/limjang/service/NoteFinder.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/service/NoteFinder.java
@@ -38,4 +38,10 @@ public class NoteFinder {
 		return limjangRepository.findAllByMemberWithAddressAndNotePriceWhereIsSharableIsTrueAndDeletedIsFalse(
 			member);
 	}
+
+	protected List<Limjang> getAllByMemberWithAddressAndNotePriceWhereIsSharableIsTrueAndDeletedIsFalseAndAddressBcodeIsNotNull(
+		Member member) {
+		return limjangRepository.findAllByMemberWithAddressAndNotePriceWhereIsSharableIsTrueAndDeletedIsFalseAndAddressBcodeIsNotNull(
+			member);
+	}
 }

--- a/src/main/java/umc/th/juinjang/api/limjang/service/NoteQueryServiceV2.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/service/NoteQueryServiceV2.java
@@ -68,7 +68,7 @@ public class NoteQueryServiceV2 {
 	}
 
 	private List<Limjang> findUnsharedSharableNotes(Member member) {
-		List<Limjang> notes = noteFinder.getAllByMemberWithAddressAndNotePriceWhereIsSharableIsTrueAndDeletedIsFalse(
+		List<Limjang> notes = noteFinder.getAllByMemberWithAddressAndNotePriceWhereIsSharableIsTrueAndDeletedIsFalseAndAddressBcodeIsNotNull(
 			member);
 		Set<Long> noteIdInSharedNotes = sharedNoteFinder.findLimjangIdsByDeletedAtIsNullAndLimjang(notes);
 

--- a/src/main/java/umc/th/juinjang/domain/limjang/repository/LimjangRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/limjang/repository/LimjangRepository.java
@@ -63,4 +63,8 @@ public interface LimjangRepository extends JpaRepository<Limjang, Long>, Limjang
 	@Query("SELECT l FROM Limjang l join fetch l.addressEntity join fetch l.limjangPrice left join fetch l.report WHERE l.memberId = :member AND l.deleted = false AND l.isSharable = true")
 	List<Limjang> findAllByMemberWithAddressAndNotePriceWhereIsSharableIsTrueAndDeletedIsFalse(
 		@Param("member") Member member);
+
+	@Query("SELECT l FROM Limjang l join fetch l.addressEntity join fetch l.limjangPrice left join fetch l.report WHERE l.memberId = :member AND l.deleted = false AND l.addressEntity.bcode is not null AND l.isSharable = true")
+	List<Limjang> findAllByMemberWithAddressAndNotePriceWhereIsSharableIsTrueAndDeletedIsFalseAndAddressBcodeIsNotNull(
+		@Param("member") Member member);
 }

--- a/src/main/java/umc/th/juinjang/domain/note/liked/model/repository/LikedNoteQueryDSLRepositoryImpl.java
+++ b/src/main/java/umc/th/juinjang/domain/note/liked/model/repository/LikedNoteQueryDSLRepositoryImpl.java
@@ -44,7 +44,8 @@ public class LikedNoteQueryDSLRepositoryImpl implements LikedNoteQueryDSLReposit
 				getWhereByPropertyType(propertyType),
 				getWhereByPriceType(priceType),
 				keywordCondition(keyword),
-				sharedNote.deletedAt.isNull()
+				sharedNote.deletedAt.isNull(),
+				limjang.deleted.isFalse()
 			)
 			.orderBy(likedNote.likedNoteId.desc())
 			.fetch();

--- a/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteQueryDSLRepositoryImpl.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteQueryDSLRepositoryImpl.java
@@ -55,7 +55,8 @@ public class SharedNoteQueryDSLRepositoryImpl implements SharedNoteQueryDSLRepos
 				getWhereByPropertyType(propertyType),
 				getWhereByPriceType(priceType),
 				keywordCondition(keyword),
-				sharedNote.deletedAt.isNull()
+				sharedNote.deletedAt.isNull(),
+				limjang.deleted.isFalse()
 			)
 			.orderBy(getOrderBySortOptions(sort))
 			.offset(pageable.getOffset())

--- a/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteQueryDSLRepositoryImpl.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteQueryDSLRepositoryImpl.java
@@ -110,7 +110,7 @@ public class SharedNoteQueryDSLRepositoryImpl implements SharedNoteQueryDSLRepos
 	private BooleanExpression getWhereByNoteType(Member user, NoteType noteType, List<Long> ids) {
 		return switch (noteType) {
 			case OWNED -> sharedNote.sharedNoteId.in(ids);
-			case SHARED -> sharedNote.member.eq(user).and(sharedNote.deletedAt.isNull());
+			case SHARED -> sharedNote.member.eq(user).and(sharedNote.deletedAt.isNull()).and(limjang.deleted.isFalse());
 			default -> null;
 		};
 	}

--- a/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteRepository.java
@@ -47,6 +47,6 @@ public interface SharedNoteRepository extends JpaRepository<SharedNote, Long>, S
 
 	boolean existsByDeletedAtIsNullAndLimjang(Limjang limjang);
 
-	@Query("SELECT s.limjang.limjangId FROM SharedNote s WHERE s.limjang in :limjangs AND s.deletedAt is null ")
+	@Query("SELECT s.limjang.limjangId FROM SharedNote s WHERE s.limjang in :limjangs AND s.deletedAt is null")
 	Set<Long> findLimjangIdsByDeletedAtIsNullAndLimjang(@Param("limjangs") List<Limjang> limjangs);
 }


### PR DESCRIPTION
## 작업내용

임장 나누기 화면에서 bcode null일 경우 나오지 않도록 쿼리 fix

## 상세설명_ & 캡쳐

- 임장 나누기 화면에서 bcode null일 경우 나오지 않도록 쿼리 fix
- 아래 화면들에서 limjang이 soft delete된 것 나오지 않도록 쿼리 fix
1. 임장 둘러보기
2. 좋아요한 임장
3. 내가 공유한 임장