### PR TITLE
[fix/#406] 조회수 NPE fix

### DIFF
--- a/src/main/java/umc/th/juinjang/api/note/shared/service/ViewCountService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/ViewCountService.java
@@ -54,6 +54,12 @@ public class ViewCountService {
 
 			if (value == null) {
 				Long viewCountFromDb = sharedNoteFinder.findViewCountById(sharedNoteId);
+
+				if (viewCountFromDb == null) {
+					log.warn("DB의 sharedNote 조회수가 null sharedNoteId={}", sharedNoteId);
+					viewCountFromDb = 0L;
+				}
+				
 				redisTemplate.opsForValue().set(key, viewCountFromDb.toString());
 				return viewCountFromDb;
 			}

--- a/src/main/java/umc/th/juinjang/domain/note/shared/model/SharedNote.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/model/SharedNote.java
@@ -83,12 +83,14 @@ public class SharedNote extends BaseEntity {
 			.month(dto.month())
 			.period(dto.period())
 			.isImageShared(dto.isImageShared())
+			.viewCount(0L)
 			.build();
 	}
 
 	public void updatePrice(long price) {
 		this.price = price;
 	}
+
 	public void updateDeletedAt(Timestamp deletedAt) {
 		this.deletedAt = deletedAt;
 	}


### PR DESCRIPTION
## 작업내용

조회수 NPE fix

## 상세설명_ & 캡쳐

- 공유노트 조회수 디폴트 값이 0인줄 알고 조회수 로직을 짰는데 생성시 null로 들어가고 있어 NPE가 났습니다. 
- 조회수 로직에서 NPE 지점을 잡아주었고, 공유노트 생성 시 조회수에 0이 들어가도록 보완했습니다.