### PR TITLE
[fix/#414] sharedNoteId로 조회되는 report 조회 api 추가

### DIFF
--- a/src/main/java/umc/th/juinjang/api/note/shared/controller/SharedNoteController.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/controller/SharedNoteController.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.api.checklist.service.response.ReportWithLimjangResponseDTO;
 import umc.th.juinjang.api.dto.ApiResponse;
 import umc.th.juinjang.api.note.shared.controller.request.ExploreSortType;
 import umc.th.juinjang.api.note.shared.controller.request.NoteType;
@@ -100,11 +102,20 @@ public class SharedNoteController {
 	}
 
 	@Operation(summary = "체크리스트 및 상세 후기 API")
-	@GetMapping("shared-note/{sharedNoteId}/checklist")
+	@GetMapping("/shared-note/{sharedNoteId}/checklist")
 	public ApiResponse<SharedNoteCheckListAndReviewResponse> findChecklistAndReview(
 		@AuthenticationPrincipal Member member,
 		@PathVariable("sharedNoteId") Long sharedNoteId) {
 		return ApiResponse.onSuccess(
 			sharedNoteQueryService.findChecklistAndReview(member, sharedNoteId));
 	}
+
+	@CrossOrigin
+	@Operation(summary = "둘러보기 리포트 조회")
+	@GetMapping("/shared-notes/{sharedNoteId}/report")
+	public ApiResponse<ReportWithLimjangResponseDTO> getReport(
+		@PathVariable(name = "sharedNoteId") Long sharedNoteId) {
+		return ApiResponse.onSuccess(sharedNoteQueryService.getReportBySharedNoteId(sharedNoteId));
+	}
+
 }

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteQueryService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteQueryService.java
@@ -10,18 +10,21 @@ import java.util.stream.IntStream;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import umc.th.juinjang.api.checklist.service.ChecklistAnswerFinder;
+import umc.th.juinjang.api.checklist.service.ReportFinder;
 import umc.th.juinjang.api.checklist.service.response.ChecklistAnswerResponseDTO;
+import umc.th.juinjang.api.checklist.service.response.ReportGetResponse;
+import umc.th.juinjang.api.checklist.service.response.ReportWithLimjangResponseDTO;
+import umc.th.juinjang.api.limjang.service.response.LimjangDetailGetResponse;
 import umc.th.juinjang.api.note.liked.service.LikedNoteFinder;
-import umc.th.juinjang.api.note.shared.service.response.SharedNoteCheckListAndReviewResponse;
 import umc.th.juinjang.api.note.shared.controller.request.ExploreSortType;
 import umc.th.juinjang.api.note.shared.controller.request.NoteType;
+import umc.th.juinjang.api.note.shared.service.response.SharedNoteCheckListAndReviewResponse;
 import umc.th.juinjang.api.note.shared.service.response.SharedNoteExploreGetResponse;
 import umc.th.juinjang.api.note.shared.service.response.SharedNoteGetResponse;
 import umc.th.juinjang.api.note.shared.service.response.UserSharedNotesGetResponse;
@@ -35,6 +38,7 @@ import umc.th.juinjang.domain.member.model.Member;
 import umc.th.juinjang.domain.note.liked.model.LikedNote;
 import umc.th.juinjang.domain.note.shared.model.SharedNote;
 import umc.th.juinjang.domain.pencil.used.model.UsedPencil;
+import umc.th.juinjang.domain.report.model.Report;
 import umc.th.juinjang.event.publisher.ApplicationRewardViewCountPublisherAdapter;
 
 @Service
@@ -48,6 +52,7 @@ public class SharedNoteQueryService {
 	private final ChecklistAnswerFinder checklistAnswerFinder;
 	private final ViewCountService viewCountService;
 	private final ApplicationRewardViewCountPublisherAdapter applicationRewardViewCountPublisherAdapter;
+	private final ReportFinder reportFinder;
 
 	@Transactional(readOnly = true)
 	public SharedNoteGetResponse findSharedNote(Member member, Long sharedNoteId) {
@@ -199,5 +204,12 @@ public class SharedNoteQueryService {
 		// 구매했다면 review 포함, 아니면 null
 		String review = isOwned ? sharedNote.getReview() : null;
 		return new SharedNoteCheckListAndReviewResponse(review, answers);
+	}
+
+	public ReportWithLimjangResponseDTO getReportBySharedNoteId(Long sharedNoteId) {
+		SharedNote sharedNote = sharedNoteFinder.findByIdWithNoteAndAddress(sharedNoteId);
+		Limjang note = sharedNote.getLimjang();
+		Report report = reportFinder.findReportByNote(note);
+		return new ReportWithLimjangResponseDTO(ReportGetResponse.of(report), LimjangDetailGetResponse.of(note));
 	}
 }


### PR DESCRIPTION
## 작업내용
sharedNoteId로 조회되는 report 조회 api를 추가하였습니다.

## 상세설명_ & 캡쳐
![image](https://github.com/user-attachments/assets/af454d76-7e70-4dca-9409-2b1d10d90319)
둘러러보기시 프론트의 편의성을 위해 sharedNoteId로 조회되는 report 조회 api를 새로 추가하였습니다.
(기존 noteId로 조회되는 report 조회 따로 존재)