### PR TITLE
[fix/#417] sharedNote에 price 필드값 업데이트

### DIFF
--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
@@ -145,10 +145,12 @@ public class SharedNoteCommandService {
 
 		// 최초 공유라면 보상 지급
 		boolean isFirstTimeShared = latestSharedNote.isEmpty();
-		Integer rewardPencilCount = isFirstTimeShared ? calculateReward(limjang, request) : 0;
+		int reward = calculateReward(limjang, request);
+		Integer rewardPencilCount = isFirstTimeShared ? reward : 0;
+		Long price = calculatePrice(reward);
 
 		// 공유 저장
-		SharedNote sharedNote = SharedNote.toSharedNote(member, limjang, request);
+		SharedNote sharedNote = SharedNote.toSharedNote(member, limjang, request, price);
 		sharedNoteUpdater.save(sharedNote);
 
 		// 보상 처리
@@ -161,11 +163,15 @@ public class SharedNoteCommandService {
 		if (request.isImageShared() == Boolean.TRUE && !limjang.getImageList().isEmpty()) {
 			validateImagesAreSafe(limjang);
 			return 7;
-		}
-		if (request.isImageShared() == Boolean.TRUE || limjang.getImageList().isEmpty()) {
+		} else
 			return 2;
-		}
-		return 0;
+	}
+
+	private Long calculatePrice(int reward) {
+		if (reward == 7)
+			return 10L;
+		else
+			return 5L;
 	}
 
 	private void validateImagesAreSafe(Limjang limjang) {

--- a/src/main/java/umc/th/juinjang/domain/note/shared/model/SharedNote.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/model/SharedNote.java
@@ -73,7 +73,7 @@ public class SharedNote extends BaseEntity {
 		return this.likeCount = (likeCount == null ? 1L : likeCount + 1);
 	}
 
-	public static SharedNote toSharedNote(Member member, Limjang limjang, SharedNotePostRequest dto) {
+	public static SharedNote toSharedNote(Member member, Limjang limjang, SharedNotePostRequest dto, Long price) {
 		return SharedNote.builder()
 			.member(member)
 			.limjang(limjang)
@@ -85,6 +85,7 @@ public class SharedNote extends BaseEntity {
 			.isImageShared(dto.isImageShared())
 			.viewCount(0L)
 			.likeCount(0L)
+			.price(price)
 			.build();
 	}
 


### PR DESCRIPTION
## 작업내용
sharedNote에 price 필드값 업데이트

## 상세설명_ & 캡쳐
![image](https://github.com/user-attachments/assets/9d6d4f54-b17a-4fc3-b582-e7df016f937c)
이미지 없을때 pirce값 5로 설정

![image](https://github.com/user-attachments/assets/702c50a7-f82f-4407-8d93-ff94b845388d)
이미지 있을때 price값 10으로 설정

![image](https://github.com/user-attachments/assets/ac14c3f4-7fea-40bd-81fc-7aa5beb30bac)
calculatePrice 메서드로 따로 빼서 진행하였습니다!
더불어 calculateReward 부분도 간결하게 변경하였습니다!

