### PR TITLE
[feat/#425] sql도 대시보드로 확인할 수 있도록 설정 추가 및 로그 포맷팅

### DIFF
--- a/src/main/java/umc/th/juinjang/monitoring/ApiFilterConfig.java
+++ b/src/main/java/umc/th/juinjang/monitoring/ApiFilterConfig.java
@@ -1,27 +1,30 @@
 package umc.th.juinjang.monitoring;
 
 import java.util.List;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
+
 import umc.th.juinjang.monitoring.ApiLoggerFilter;
 
 @Configuration
 @Slf4j
 public class ApiFilterConfig {
 
-  @Value("${logging.api.excluded-paths}")
-  private List<String> excludedUrls;
+	@Value("${logging.api.excluded-paths}")
+	private List<String> excludedUrls;
 
-  @Bean
-  public FilterRegistrationBean<ApiLoggerFilter> loggingFilter() {
-    FilterRegistrationBean<ApiLoggerFilter> registrationBean = new FilterRegistrationBean<>();
-    registrationBean.setFilter(new ApiLoggerFilter(excludedUrls));
-    registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE); // 순서 설정
-    registrationBean.setUrlPatterns(List.of("/*"));
-    return registrationBean;
-  }
+	@Bean
+	public FilterRegistrationBean<ApiLoggerFilter> loggingFilter() {
+		FilterRegistrationBean<ApiLoggerFilter> registrationBean = new FilterRegistrationBean<>();
+		registrationBean.setFilter(new ApiLoggerFilter(excludedUrls));
+		registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE); // 순서 설정
+		registrationBean.setUrlPatterns(List.of("/*"));
+		return registrationBean;
+	}
 }

--- a/src/main/java/umc/th/juinjang/monitoring/ApiLogRequestLogGenerator.java
+++ b/src/main/java/umc/th/juinjang/monitoring/ApiLogRequestLogGenerator.java
@@ -1,52 +1,61 @@
 package umc.th.juinjang.monitoring;
 
 import jakarta.servlet.http.HttpServletRequest;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
+
 import org.springframework.web.util.ContentCachingRequestWrapper;
 
 public class ApiLogRequestLogGenerator extends ApiLogGenerator {
 
-  private final ContentCachingRequestWrapper request;
+	private final ContentCachingRequestWrapper request;
+	private static final List<String> ALLOWED_HEADERS = List.of(
+		"x-forwarded-for", "x-real-ip", "user-agent", "content-type", "accept", "host"
+	);
 
-  public ApiLogRequestLogGenerator(ContentCachingRequestWrapper request) {
-    this.request = request;
-  }
+	public ApiLogRequestLogGenerator(ContentCachingRequestWrapper request) {
+		this.request = request;
+	}
 
-  @Override
-  public String generateLog() {
-    StringBuilder logBuilder = new StringBuilder();
+	@Override
+	public String generateLog() {
+		StringBuilder logBuilder = new StringBuilder();
 
-    logBuilder.append("Request : ").append(" ");
-    logBuilder.append(getBaseLogInfo());
-    logBuilder.append("[method] ").append(request.getMethod()).append(" ");
-    logBuilder.append("[uri] ").append(getQuery()).append(" ");
-    logBuilder.append("[headers] ").append(getHeadersAsString(request)).append(" ");
-    logBuilder.append("[requestBody] ").append(getBody(request.getContentAsByteArray())).append(" ");
+		logBuilder.append("Request : ").append(" ");
+		// logBuilder.append(getBaseLogInfo());
+		logBuilder.append("[method] ").append(request.getMethod()).append(" ");
+		logBuilder.append("[uri] ").append(getQuery()).append("\n");
+		logBuilder.append("[headers] ").append(getHeadersAsString(request)).append("\n");
+		logBuilder.append("[requestBody] ").append(getBody(request.getContentAsByteArray())).append(" ");
 
-    return logBuilder.toString();
-  }
+		return logBuilder.toString();
+	}
 
-  private String getQuery() {
-    String uri = request.getRequestURI();
-    String queryString = request.getQueryString();
+	private String getQuery() {
+		String uri = request.getRequestURI();
+		String queryString = request.getQueryString();
 
-    if (queryString != null) {
-      uri += "?" + queryString;
-    }
-    return uri;
-  }
+		if (queryString != null) {
+			uri += "?" + queryString;
+		}
+		return uri;
+	}
 
-  private String getHeadersAsString(HttpServletRequest request) {
-    return Collections.list(request.getHeaderNames()).stream()
-        .filter(headerName -> !headerName.equalsIgnoreCase("Authorization"))
-        .filter(headerName -> !headerName.equalsIgnoreCase("refresh-token"))
-        .map(headerName -> headerName + "=" + request.getHeader(headerName))
-        .collect(Collectors.joining(", "));
-  }
+	private String getHeadersAsString(HttpServletRequest request) {
+		return ALLOWED_HEADERS.stream()
+			.map(header -> {
+				String value = request.getHeader(header);
+				return value != null ? header + "=" + value : null;
+			})
+			.filter(Objects::nonNull)
+			.collect(Collectors.joining(", "));
+	}
 
-  protected String getBody(byte[] info) {
-    return new String(info, StandardCharsets.UTF_8).replace("\n", "").replace("\r", "");
-  }
+	protected String getBody(byte[] info) {
+		return new String(info, StandardCharsets.UTF_8).replace("\n", "").replace("\r", "");
+	}
 }

--- a/src/main/java/umc/th/juinjang/monitoring/ApiLogResponseGenerator.java
+++ b/src/main/java/umc/th/juinjang/monitoring/ApiLogResponseGenerator.java
@@ -2,42 +2,44 @@ package umc.th.juinjang.monitoring;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.nio.charset.StandardCharsets;
+
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
 public class ApiLogResponseGenerator extends ApiLogGenerator {
-  private final ContentCachingResponseWrapper response;
+	private final ContentCachingResponseWrapper response;
 
-  public ApiLogResponseGenerator(ContentCachingResponseWrapper response) {
-    this.response = response;
-  }
+	public ApiLogResponseGenerator(ContentCachingResponseWrapper response) {
+		this.response = response;
+	}
 
-  @Override
-  public String generateLog() {
-    StringBuilder logBuilder = new StringBuilder();
+	@Override
+	public String generateLog() {
+		StringBuilder logBuilder = new StringBuilder();
 
-    logBuilder.append("Response : ").append(" ");
-    logBuilder.append(getBaseLogInfo());
-    logBuilder.append("[status] ").append(response.getStatus()).append(" ");
-    logBuilder.append("[responseBody] ").append(getBody(response.getContentAsByteArray())).append(" ");
+		logBuilder.append("Response : ").append(" ");
+		// logBuilder.append(getBaseLogInfo());
+		logBuilder.append("[status] ").append(response.getStatus()).append(" ");
+		logBuilder.append("[responseBody] ").append(getBody(response.getContentAsByteArray())).append(" ");
 
-    return logBuilder.toString();
-  }
+		return logBuilder.toString();
+	}
 
-  protected String getBody(byte[] info) {
-    String responseBody = "";
-    try {
-      ObjectMapper objectMapper = new ObjectMapper();
-      JsonNode rootNode = objectMapper.readTree(new String(info, StandardCharsets.UTF_8));
-      responseBody = replaceToken(rootNode.path("message").asText("N/A"));
-    } catch (Exception e) {
-      logger.error("responseBody 추출 오류");
-    }
-    return responseBody;
-  }
+	protected String getBody(byte[] info) {
+		String responseBody = "";
+		try {
+			ObjectMapper objectMapper = new ObjectMapper();
+			JsonNode rootNode = objectMapper.readTree(new String(info, StandardCharsets.UTF_8));
+			responseBody = replaceToken(rootNode.path("message").asText("N/A"));
+		} catch (Exception e) {
+			logger.error("responseBody 추출 오류");
+		}
+		return responseBody;
+	}
 
-  private String replaceToken(String responseBody) {
-    return responseBody.replaceAll("\"accessToken\":\"[^\"]*\"", "\"accessToken\":\"[TOKEN]\"")
-        .replaceAll("\"refreshToken\":\"[^\"]*\"", "\"refreshToken\":\"[TOKEN]\"");
-  }
+	private String replaceToken(String responseBody) {
+		return responseBody.replaceAll("\"accessToken\":\"[^\"]*\"", "\"accessToken\":\"[TOKEN]\"")
+			.replaceAll("\"refreshToken\":\"[^\"]*\"", "\"refreshToken\":\"[TOKEN]\"");
+	}
 }

--- a/src/main/java/umc/th/juinjang/monitoring/ApiLoggerFilter.java
+++ b/src/main/java/umc/th/juinjang/monitoring/ApiLoggerFilter.java
@@ -6,9 +6,12 @@ import static umc.th.juinjang.common.LoggerProvider.registerRequestId;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import java.util.List;
 import java.util.UUID;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.slf4j.Logger;
 import org.slf4j.MDC;
 import org.springframework.util.AntPathMatcher;
@@ -18,40 +21,41 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 
 @Slf4j
 public class ApiLoggerFilter extends OncePerRequestFilter {
-  private static final Logger logger = getLogger(ApiLoggerFilter.class);
-  private final ApiLoggerFactory apiLoggerFactory;
-  private final List<String> EXCLUDED_URLS;
+	private static final Logger logger = getLogger(ApiLoggerFilter.class);
+	private final ApiLoggerFactory apiLoggerFactory;
+	private final List<String> EXCLUDED_URLS;
 
-  public ApiLoggerFilter(List<String> EXCLUDED_URLS) {
-    this.EXCLUDED_URLS = EXCLUDED_URLS;
-    this.apiLoggerFactory = new ApiLoggerFactory();
-  }
+	public ApiLoggerFilter(List<String> EXCLUDED_URLS) {
+		this.EXCLUDED_URLS = EXCLUDED_URLS;
+		this.apiLoggerFactory = new ApiLoggerFactory();
+	}
 
-  @Override
-  protected void doFilterInternal(HttpServletRequest servletRequest, HttpServletResponse servletResponse, FilterChain chain) {
-    ContentCachingRequestWrapper request = new ContentCachingRequestWrapper(servletRequest);
-    ContentCachingResponseWrapper response =  new ContentCachingResponseWrapper(servletResponse);
-    registerRequestId(UUID.randomUUID().toString());
+	@Override
+	protected void doFilterInternal(HttpServletRequest servletRequest, HttpServletResponse servletResponse,
+		FilterChain chain) {
+		ContentCachingRequestWrapper request = new ContentCachingRequestWrapper(servletRequest);
+		ContentCachingResponseWrapper response = new ContentCachingResponseWrapper(servletResponse);
+		registerRequestId(UUID.randomUUID().toString());
 
-    try {
-      if (shouldNotFilter(request)) {
-        chain.doFilter(request, response);
-        return;
-      }
-      chain.doFilter(request, response);
-      apiLoggerFactory.createRequestLogger(request);
-      apiLoggerFactory.createResponseLogger(response);
-      response.copyBodyToResponse();
-    } catch (Exception e) {
-      logger.error("APILogger 필터 오류");
-    } finally {
-      MDC.clear();
-    }
-  }
+		try {
+			if (shouldNotFilter(request)) {
+				chain.doFilter(request, response);
+				return;
+			}
+			chain.doFilter(request, response);
+			apiLoggerFactory.createRequestLogger(request);
+			apiLoggerFactory.createResponseLogger(response);
+			response.copyBodyToResponse();
+		} catch (Exception e) {
+			logger.error("APILogger 필터 오류, message : {} ", e.getMessage());
+		} finally {
+			MDC.clear();
+		}
+	}
 
-  @Override
-  protected boolean shouldNotFilter(HttpServletRequest request) {
-    AntPathMatcher pathMatcher = new AntPathMatcher();
-    return EXCLUDED_URLS.stream().anyMatch(pattern -> pathMatcher.match(pattern, request.getRequestURI()));
-  }
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		AntPathMatcher pathMatcher = new AntPathMatcher();
+		return EXCLUDED_URLS.stream().anyMatch(pattern -> pathMatcher.match(pattern, request.getRequestURI()));
+	}
 }

--- a/src/main/resources/logback-appender.xml
+++ b/src/main/resources/logback-appender.xml
@@ -1,92 +1,113 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <included>
-  <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
 
-  <property name="CONSOLE_LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%clr(%-5level)] [%thread] [%logger{1}] - %msg%n"/>
+    <property name="CONSOLE_LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%clr(%-5level)] [%thread] [%logger{1}] - %msg%n"/>
 
-  <property name="INFO_LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%-5level] [%X{request_id:-NORequestID}] [%X{user_id:-unknown}] [%thread] [%logger{1}] - %msg%n"/>
-  <property name="WARN_LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%-5level] [%X{request_id:-NORequestID}] [%X{user_id:-unknown}] [%thread] [%logger{1}] - %msg%n"/>
-  <property name="ERROR_LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%-5level] [%X{request_id:-NORequestID}] [%X{user_id:-unknown}] [%thread] [%logger{1}] - %msg%n"/>
+    <property name="BASE_LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%-5level] [%X{request_id:-NORequestID}] [%X{user_id:-unknown}] [%thread] [%logger{1}] - %msg%n"/>
 
-  <property name="API_FILE_LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%-5level] [%thread] [%logger{1}] - %msg%n"/>
-  <property name="API_CONSOLE_LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%clr(%-5level)] [%thread] [%logger{1}] - %msg%n"/>
+    <property name="FILE_LOG_PATTERN"
+              value="%n[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%-5level] [%thread] [%logger{1}] [request_id=%X{request_id}] [user_id=%X{user_id}] %n%msg%n"/>
 
-  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-    <layout class="ch.qos.logback.classic.PatternLayout">
-      <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
-    </layout>
-  </appender>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+        </layout>
+    </appender>
 
-  <appender name="API_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-    <layout class="ch.qos.logback.classic.PatternLayout">
-      <Pattern>${API_CONSOLE_LOG_PATTERN}</Pattern>
-    </layout>
-  </appender>
+    <appender name="API_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+        </layout>
+    </appender>
 
-  <appender name="CONSOLE_INFO_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>${LOG_PATH}/console/info-${SERVER_INFO}-console.log</file>
-    <filter class="ch.qos.logback.classic.filter.LevelFilter">
-      <level>INFO</level>
-      <onMatch>ACCEPT</onMatch>
-      <onMismatch>DENY</onMismatch>
-    </filter>
-    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>${LOG_PATH}/console/info-${SERVER_INFO}-console-%d{yyyy-MM-dd}.%i.txt</fileNamePattern>
-      <maxFileSize>20MB</maxFileSize>
-      <maxHistory>7</maxHistory>
-      <totalSizeCap>100MB</totalSizeCap>
-    </rollingPolicy>
-    <encoder>
-      <pattern>${INFO_LOG_PATTERN}</pattern>
-    </encoder>
-  </appender>
+    <appender name="SQL_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+        </layout>
+    </appender>
 
-  <appender name="CONSOLE_WARN_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>${LOG_PATH}/console/warn-${SERVER_INFO}-console.log</file>
-    <filter class="ch.qos.logback.classic.filter.LevelFilter">
-      <level>WARN</level>
-      <onMatch>ACCEPT</onMatch>
-      <onMismatch>DENY</onMismatch>
-    </filter>
-    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>${LOG_PATH}/console/warn-${SERVER_INFO}-console-%d{yyyy-MM-dd}.%i.txt</fileNamePattern>
-      <maxFileSize>20MB</maxFileSize>
-      <maxHistory>7</maxHistory>
-      <totalSizeCap>100MB</totalSizeCap>
-    </rollingPolicy>
-    <encoder>
-      <pattern>${WARN_LOG_PATTERN}</pattern>
-    </encoder>
-  </appender>
+    <appender name="CONSOLE_INFO_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/console/info-${SERVER_INFO}-console.log</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/console/info-${SERVER_INFO}-console-%d{yyyy-MM-dd}.%i.txt</fileNamePattern>
+            <maxFileSize>20MB</maxFileSize>
+            <maxHistory>7</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${BASE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
 
-  <appender name="CONSOLE_ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>${LOG_PATH}/console/error-${SERVER_INFO}-console.log</file>
-    <filter class="ch.qos.logback.classic.filter.LevelFilter">
-      <level>ERROR</level>
-      <onMatch>ACCEPT</onMatch>
-      <onMismatch>DENY</onMismatch>
-    </filter>
-    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>${LOG_PATH}/console/error-${SERVER_INFO}-console-%d{yyyy-MM-dd}.%i.txt</fileNamePattern>
-      <maxFileSize>20MB</maxFileSize>
-      <maxHistory>7</maxHistory>
-      <totalSizeCap>100MB</totalSizeCap>
-    </rollingPolicy>
-    <encoder>
-      <pattern>${ERROR_LOG_PATTERN}</pattern>
-    </encoder>
-  </appender>
+    <appender name="CONSOLE_WARN_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/console/warn-${SERVER_INFO}-console.log</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/console/warn-${SERVER_INFO}-console-%d{yyyy-MM-dd}.%i.txt</fileNamePattern>
+            <maxFileSize>20MB</maxFileSize>
+            <maxHistory>7</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${BASE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
 
-  <appender name="API_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>${LOG_PATH}/api/${SERVER_INFO}-api.log</file>
-    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>${LOG_PATH}/api/${SERVER_INFO}-api-%d{yyyy-MM-dd}.%i.txt</fileNamePattern>
-      <maxFileSize>20MB</maxFileSize>
-      <maxHistory>7</maxHistory>
-      <totalSizeCap>100MB</totalSizeCap>
-    </rollingPolicy>
-    <encoder>
-      <pattern>${API_FILE_LOG_PATTERN}</pattern>
-    </encoder>
-  </appender>
+    <appender name="CONSOLE_ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/console/error-${SERVER_INFO}-console.log</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/console/error-${SERVER_INFO}-console-%d{yyyy-MM-dd}.%i.txt</fileNamePattern>
+            <maxFileSize>20MB</maxFileSize>
+            <maxHistory>7</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${BASE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="API_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/api/${SERVER_INFO}-api.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/api/${SERVER_INFO}-api-%d{yyyy-MM-dd}.%i.txt</fileNamePattern>
+            <maxFileSize>20MB</maxFileSize>
+            <maxHistory>7</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+
+    <appender name="SQL_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/sql/sql-${SERVER_INFO}.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/sql/sql-${SERVER_INFO}-%d{yyyy-MM-dd}.%i.txt</fileNamePattern>
+            <maxFileSize>20MB</maxFileSize>
+            <maxHistory>7</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
 </included>

--- a/src/main/resources/logback-appender.xml
+++ b/src/main/resources/logback-appender.xml
@@ -23,12 +23,6 @@
         </layout>
     </appender>
 
-    <appender name="SQL_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <layout class="ch.qos.logback.classic.PatternLayout">
-            <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
-        </layout>
-    </appender>
-
     <appender name="CONSOLE_INFO_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_PATH}/console/info-${SERVER_INFO}-console.log</file>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">

--- a/src/main/resources/logback-dev.xml
+++ b/src/main/resources/logback-dev.xml
@@ -1,22 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-  <include resource="logback-appender.xml"/>
-  <springProperty scope="context" name="LOG_PATH" source="logging.file.path"/>
-  <property name="LOG_PATH" value="${LOG_PATH}" />
-  <property name="SERVER_INFO" value="dev" />
+    <include resource="logback-appender.xml"/>
+    <springProperty scope="context" name="LOG_PATH" source="logging.file.path"/>
+    <property name="LOG_PATH" value="${LOG_PATH}"/>
+    <property name="SERVER_INFO" value="dev"/>
 
-  <root level="INFO">
-    <appender-ref ref="CONSOLE"/>
-    <appender-ref ref="CONSOLE_INFO_FILE"/>
-    <appender-ref ref="CONSOLE_WARN_FILE"/>
-    <appender-ref ref="CONSOLE_ERROR_FILE"/>
-  </root>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="CONSOLE_INFO_FILE"/>
+        <appender-ref ref="CONSOLE_WARN_FILE"/>
+        <appender-ref ref="CONSOLE_ERROR_FILE"/>
+    </root>
 
-  <logger name="umc.th.juinjang.monitoring.ApiLogPrinter" level="INFO" additivity="false">
-    <appender-ref ref="API_FILE"/>
-    <appender-ref ref="API_CONSOLE"/>
-  </logger>
+    <logger name="umc.th.juinjang.monitoring.ApiLogPrinter" level="INFO" additivity="false">
+        <appender-ref ref="API_FILE"/>
+        <appender-ref ref="API_CONSOLE"/>
+    </logger>
 
-  <logger name="org.hibernate" level="ERROR"/>
-  <logger name="org.springframework.web" level="INFO"/>
+    <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
+        <appender-ref ref="SQL_FILE"/>
+        <appender-ref ref="SQL_CONSOLE"/>
+    </logger>
+
+    <logger name="org.hibernate.orm.jdbc.bind" level="TRACE" additivity="false">
+        <appender-ref ref="SQL_FILE"/>
+        <appender-ref ref="SQL_CONSOLE"/>
+    </logger>
+
+    <logger name="org.hibernate" level="ERROR"/>
+    <logger name="org.springframework.web" level="INFO"/>
+    <logger name="org.springframework.boot.start.endpoint.web" level="ERROR" additivity="false"/>
+
 </configuration>

--- a/src/main/resources/logback-dev.xml
+++ b/src/main/resources/logback-dev.xml
@@ -19,12 +19,10 @@
 
     <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
         <appender-ref ref="SQL_FILE"/>
-        <appender-ref ref="SQL_CONSOLE"/>
     </logger>
 
     <logger name="org.hibernate.orm.jdbc.bind" level="TRACE" additivity="false">
         <appender-ref ref="SQL_FILE"/>
-        <appender-ref ref="SQL_CONSOLE"/>
     </logger>
 
     <logger name="org.hibernate" level="ERROR"/>

--- a/src/main/resources/logback-local.xml
+++ b/src/main/resources/logback-local.xml
@@ -19,12 +19,10 @@
 
     <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
         <appender-ref ref="SQL_FILE"/>
-        <appender-ref ref="SQL_CONSOLE"/>
     </logger>
 
     <logger name="org.hibernate.orm.jdbc.bind" level="TRACE" additivity="false">
         <appender-ref ref="SQL_FILE"/>
-        <appender-ref ref="SQL_CONSOLE"/>
     </logger>
 
     <logger name="org.hibernate" level="ERROR"/>

--- a/src/main/resources/logback-local.xml
+++ b/src/main/resources/logback-local.xml
@@ -1,23 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-  <include resource="logback-appender.xml"/>
-  <springProperty scope="context" name="LOG_PATH" source="logging.file.path"/>
-  <property name="LOG_PATH" value="${LOG_PATH}" />
-  <property name="SERVER_INFO" value="local" />
+    <include resource="logback-appender.xml"/>
+    <springProperty scope="context" name="LOG_PATH" source="logging.file.path"/>
+    <property name="LOG_PATH" value="${LOG_PATH}"/>
+    <property name="SERVER_INFO" value="local"/>
 
-  <root level="INFO">
-    <appender-ref ref="CONSOLE"/>
-    <appender-ref ref="CONSOLE_INFO_FILE"/>
-    <appender-ref ref="CONSOLE_WARN_FILE"/>
-    <appender-ref ref="CONSOLE_ERROR_FILE"/>
-  </root>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="CONSOLE_INFO_FILE"/>
+        <appender-ref ref="CONSOLE_WARN_FILE"/>
+        <appender-ref ref="CONSOLE_ERROR_FILE"/>
+    </root>
 
-  <logger name="umc.th.juinjang.monitoring.ApiLogPrinter" level="INFO" additivity="false">
-    <appender-ref ref="API_FILE"/>
-    <appender-ref ref="API_CONSOLE"/>
-  </logger>
+    <logger name="umc.th.juinjang.monitoring.ApiLogPrinter" level="INFO" additivity="false">
+        <appender-ref ref="API_FILE"/>
+        <appender-ref ref="API_CONSOLE"/>
+    </logger>
 
-  <logger name="org.hibernate" level="ERROR"/>
-  <logger name="org.springframework.web" level="INFO"/>
-  <logger name="org.springframework.boot.start.endpoint.web" level="ERROR" additivity="false" />
+    <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
+        <appender-ref ref="SQL_FILE"/>
+        <appender-ref ref="SQL_CONSOLE"/>
+    </logger>
+
+    <logger name="org.hibernate.orm.jdbc.bind" level="TRACE" additivity="false">
+        <appender-ref ref="SQL_FILE"/>
+        <appender-ref ref="SQL_CONSOLE"/>
+    </logger>
+
+    <logger name="org.hibernate" level="ERROR"/>
+    <logger name="org.springframework.web" level="INFO"/>
+    <logger name="org.springframework.boot.start.endpoint.web" level="ERROR" additivity="false"/>
 </configuration>

--- a/src/main/resources/logback-prod.xml
+++ b/src/main/resources/logback-prod.xml
@@ -19,12 +19,10 @@
 
     <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
         <appender-ref ref="SQL_FILE"/>
-        <appender-ref ref="SQL_CONSOLE"/>
     </logger>
 
     <logger name="org.hibernate.orm.jdbc.bind" level="TRACE" additivity="false">
         <appender-ref ref="SQL_FILE"/>
-        <appender-ref ref="SQL_CONSOLE"/>
     </logger>
 
     <logger name="org.hibernate" level="ERROR"/>

--- a/src/main/resources/logback-prod.xml
+++ b/src/main/resources/logback-prod.xml
@@ -1,22 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-  <include resource="logback-appender.xml"/>
-  <springProperty scope="context" name="LOG_PATH" source="logging.file.path"/>
-  <property name="LOG_PATH" value="${LOG_PATH}" />
-  <property name="SERVER_INFO" value="prod" />
+    <include resource="logback-appender.xml"/>
+    <springProperty scope="context" name="LOG_PATH" source="logging.file.path"/>
+    <property name="LOG_PATH" value="${LOG_PATH}"/>
+    <property name="SERVER_INFO" value="prod"/>
 
-  <root level="INFO">
-    <appender-ref ref="CONSOLE"/>
-    <appender-ref ref="CONSOLE_INFO_FILE"/>
-    <appender-ref ref="CONSOLE_WARN_FILE"/>
-    <appender-ref ref="CONSOLE_ERROR_FILE"/>
-  </root>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="CONSOLE_INFO_FILE"/>
+        <appender-ref ref="CONSOLE_WARN_FILE"/>
+        <appender-ref ref="CONSOLE_ERROR_FILE"/>
+    </root>
 
-  <logger name="umc.th.juinjang.monitoring.ApiLogPrinter" level="INFO" additivity="false">
-    <appender-ref ref="API_FILE"/>
-    <appender-ref ref="API_CONSOLE"/>
-  </logger>
+    <logger name="umc.th.juinjang.monitoring.ApiLogPrinter" level="INFO" additivity="false">
+        <appender-ref ref="API_FILE"/>
+        <appender-ref ref="API_CONSOLE"/>
+    </logger>
 
-  <logger name="org.hibernate" level="ERROR"/>
-  <logger name="org.springframework.web" level="INFO"/>
+    <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
+        <appender-ref ref="SQL_FILE"/>
+        <appender-ref ref="SQL_CONSOLE"/>
+    </logger>
+
+    <logger name="org.hibernate.orm.jdbc.bind" level="TRACE" additivity="false">
+        <appender-ref ref="SQL_FILE"/>
+        <appender-ref ref="SQL_CONSOLE"/>
+    </logger>
+
+    <logger name="org.hibernate" level="ERROR"/>
+    <logger name="org.springframework.web" level="INFO"/>
 </configuration>


### PR DESCRIPTION
## 작업내용

sql도 대시보드로 확인할 수 있도록 설정 추가 및 로그 포맷팅

## 상세설명_ & 캡쳐

- sql 로그 확인할 수 있도록 각각 환경 파일들에 아래 코드 추가했습니다. 
logback-{profile}.xml

```xml
    <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
        <appender-ref ref="SQL_FILE"/>
        <appender-ref ref="SQL_CONSOLE"/>
    </logger>

    <logger name="org.hibernate.orm.jdbc.bind" level="TRACE" additivity="false">
        <appender-ref ref="SQL_FILE"/>
        <appender-ref ref="SQL_CONSOLE"/>
    </logger>
```

- yml에 아래 설정 추가 예정
```yaml
  level:
    org.hibernate.SQL: DEBUG
    org.hibernate.orm.jdbc.bind: TRACE
```


- promtail 설정 파일 완료 - 추후 배포 시 prod 서버에도 필요
- home디렉토리/logs 아래 sql 디렉토리 생성완료(docker promtail 컨테이너에 마운트 위해 필요한 부분, 로그 파일 흐름 : 주인장 컨테이너 --> 홈 디렉토리 --> 프롬테일 컨테이너 ) 컨테이너끼리 파일 공유가 불가해 이렇게 구성

# 로그 포맷
## sql - 쿼리, 바인딩 파라미터 함께 뜨도록

```
[2025-06-28 18:55:44.885] [DEBUG] [http-nio-8080-exec-2] [o.h.SQL] [request_id=8518dff2-011f-48c7-8140-5726a4166ad0] [user_id=1] 

    select
        pp1_0.purchased_pencil_id,
        pp1_0.app_account_token,
        pp1_0.delivery_status,
        pp1_0.member_id,
        pp1_0.play_time,
        pp1_0.price,
        pp1_0.purchase_quantity,
        pp1_0.purchased_at,
        pp1_0.remain_quantity,
        pp1_0.retry_count,
        pp1_0.title,
        pp1_0.transaction_id,
        pp1_0.transaction_status,
        pp1_0.updated_at 
    from
        purchased_pencil pp1_0 
    where
        pp1_0.member_id=? 
        and pp1_0.delivery_status=0 
    order by
        pp1_0.purchased_at desc

[2025-06-28 18:55:44.886] [TRACE] [http-nio-8080-exec-2] [o.h.o.j.bind] [request_id=8518dff2-011f-48c7-8140-5726a4166ad0] [user_id=1] 
binding parameter (1:BIGINT) <- [1]
```

## api 파일 로그

```plain text
[2025-06-28 18:55:44.889] [INFO ] [http-nio-8080-exec-2] [u.t.j.m.ApiLogPrinter] [request_id=8518dff2-011f-48c7-8140-5726a4166ad0] [user_id=1] 
Request :  [method] GET [uri] /api/v2/pencil/purchased
[headers] user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36, accept=*/*, host=localhost:8080
[requestBody]  

[2025-06-28 18:55:44.889] [INFO ] [http-nio-8080-exec-2] [u.t.j.m.ApiLogPrinter] [request_id=8518dff2-011f-48c7-8140-5726a4166ad0] [user_id=1] 
Response :  [status] 200 [responseBody] 성공입니다. 
```


# JWT 관련 

- 아래처럼 로그에서 사용자의 user_id를 추적하고 있습니다. 해당 과정은 MDC를 통해 구현하고 있습니다. MDC는 스레드 단위로 key값을 저장하고, get하여 데이터를 사용할 수 있는 라이브러리입니다.

logback-appender.xml
```xml
 <property name="FILE_LOG_PATTERN"
              value="%n[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%-5level] [%thread] [%logger{1}] [request_id=%X{request_id}] [user_id=%X{user_id}] %n%msg%n"/>
```

- 이를 위해 jwt 로직에서 user_id를 MDC에 넣는 로직을 사용하고 있습니다. 
- **토큰을 검증하는 과정에서 검증 성공 시 로그인한 유저의 ID를 MDC에 넣는 로직을 사용하고 있습니다**. 참고 부탁드립니다.

JwtService.java

```java
    public Authentication getAuthentication(String token) {
        System.out.println(this.getMemberIdFromJwtToken(token));

        UserDetails userDetails =   userDetailService.loadUserByUsername(this.getMemberIdFromJwtToken(token).toString());
        
       registerUserId(String.valueOf(this.getMemberIdFromJwtToken(token))); // 이 부분 
        
      return new UsernamePasswordAuthenticationToken(userDetails, token, userDetails.getAuthorities());
    }

```

LoggerProvider.java
```java
  public static void registerUserId(String userId) {
    MDC.put(USER_ID, userId);
  }
```