### PR TITLE
fix #430 - 1. Reward 달성 시에 content 수정 2. 얻은 연필 목록에서 buildingName 같이 넘기도록 수정

### DIFF
--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
@@ -95,7 +95,8 @@ public class SharedNoteCommandService {
 	}
 
 	private AcquiredPencil createAcquiredPencil(Long sharedNoteId, Member seller, Long price, AcquiredType type) {
-		return AcquiredPencil.create(seller, "", sharedNoteId, price, false, type);
+		String content = "노트 공유 완료!";
+		return AcquiredPencil.create(seller, content, sharedNoteId, price, false, type);
 	}
 
 	private void consumePurchasedPencils(Member buyer, long unpaidPencil) {

--- a/src/main/java/umc/th/juinjang/api/pencil/service/AcquiredPencilFinder.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/service/AcquiredPencilFinder.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
+import umc.th.juinjang.api.pencil.service.response.AcquiredPencilResponse;
 import umc.th.juinjang.domain.member.model.Member;
 import umc.th.juinjang.domain.pencil.acquired.model.AcquiredPencil;
 import umc.th.juinjang.domain.pencil.acquired.repository.AcquiredPencilRepository;
@@ -15,8 +16,8 @@ public class AcquiredPencilFinder {
 
 	private final AcquiredPencilRepository acquiredPencilRepository;
 
-	public List<AcquiredPencil> findAllByMemberOrderByCreatedAtDesc(Member member) {
-		return acquiredPencilRepository.findAllByMemberOrderByCreatedAtDesc(member);
+	public List<AcquiredPencilResponse> findAllByMemberOrderByCreatedAtDesc(Member member) {
+		return acquiredPencilRepository.findAllByMemberWithBuildingNameOrderByCreatedAtDesc(member);
 	}
 
 	public boolean existsByMemberAndIsReadFalse(Member member) {

--- a/src/main/java/umc/th/juinjang/api/pencil/service/PencilQueryService.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/service/PencilQueryService.java
@@ -25,7 +25,6 @@ import umc.th.juinjang.api.pencil.service.response.UsedPencilResponse;
 import umc.th.juinjang.api.pencilAccount.service.PencilAccountFinder;
 import umc.th.juinjang.common.exception.handler.PencilAccountHandler;
 import umc.th.juinjang.domain.member.model.Member;
-import umc.th.juinjang.domain.pencil.acquired.model.AcquiredPencil;
 import umc.th.juinjang.domain.pencil.purchased.model.PurchasedPencil;
 import umc.th.juinjang.domain.pencil.used.model.UsedPencil;
 import umc.th.juinjang.domain.pencilaccount.model.PencilAccount;
@@ -42,10 +41,7 @@ public class PencilQueryService {
 	private final PencilAccountFinder pencilAccountFinder;
 
 	public List<AcquiredPencilResponse> getAcquiredPencils(Member member) {
-		List<AcquiredPencil> acquiredPencils = acquiredPencilFinder.findAllByMemberOrderByCreatedAtDesc(member);
-		return acquiredPencils.stream()
-			.map(AcquiredPencilResponse::from)
-			.toList();
+		return acquiredPencilFinder.findAllByMemberOrderByCreatedAtDesc(member);
 	}
 
 	public List<PurchasedPencilResponse> getPurchasedPencils(Member member) {

--- a/src/main/java/umc/th/juinjang/api/pencil/service/response/AcquiredPencilResponse.java
+++ b/src/main/java/umc/th/juinjang/api/pencil/service/response/AcquiredPencilResponse.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 
 import lombok.Builder;
 import lombok.Getter;
-import umc.th.juinjang.domain.pencil.acquired.model.AcquiredPencil;
+import umc.th.juinjang.domain.pencil.acquired.model.AcquiredType;
 
 @Getter
 public class AcquiredPencilResponse {
@@ -13,31 +13,34 @@ public class AcquiredPencilResponse {
 	private final String content;
 	private final Long sharedNoteId;
 	private final Long acquiredQuantity;
+	private final String buildingName;
 	private final boolean isRead;
 	private final String type;
 	private final LocalDateTime createdAt;
 
 	@Builder
 	public AcquiredPencilResponse(Long acquiredPencilId, String content, Long sharedNoteId, Long acquiredQuantity,
-		boolean isRead, String type, LocalDateTime createdAt) {
+		String buildingName, boolean isRead, String type, LocalDateTime createdAt) {
 		this.acquiredPencilId = acquiredPencilId;
 		this.content = content;
 		this.sharedNoteId = sharedNoteId;
 		this.acquiredQuantity = acquiredQuantity;
+		this.buildingName = buildingName;
 		this.isRead = isRead;
 		this.type = type;
 		this.createdAt = createdAt;
 	}
 
-	public static AcquiredPencilResponse from(AcquiredPencil acquiredPencil) {
-		return AcquiredPencilResponse.builder()
-			.acquiredPencilId(acquiredPencil.getId())
-			.content(acquiredPencil.getContent())
-			.sharedNoteId(acquiredPencil.getSharedNoteId())
-			.acquiredQuantity(acquiredPencil.getAcquiredQuantity())
-			.isRead(acquiredPencil.isRead())
-			.type(acquiredPencil.getType().name())
-			.createdAt(acquiredPencil.getCreatedAt())
-			.build();
+	public AcquiredPencilResponse(Long acquiredPencilId, String content, Long sharedNoteId,
+		Long acquiredQuantity, boolean isRead, AcquiredType type,
+		LocalDateTime createdAt, String buildingName) {
+		this.acquiredPencilId = acquiredPencilId;
+		this.content = content;
+		this.sharedNoteId = sharedNoteId;
+		this.acquiredQuantity = acquiredQuantity;
+		this.isRead = isRead;
+		this.type = type.name();
+		this.createdAt = createdAt;
+		this.buildingName = buildingName;
 	}
 }

--- a/src/main/java/umc/th/juinjang/domain/pencil/acquired/repository/AcquiredPencilRepository.java
+++ b/src/main/java/umc/th/juinjang/domain/pencil/acquired/repository/AcquiredPencilRepository.java
@@ -3,13 +3,25 @@ package umc.th.juinjang.domain.pencil.acquired.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import umc.th.juinjang.api.pencil.service.response.AcquiredPencilResponse;
 import umc.th.juinjang.domain.member.model.Member;
 import umc.th.juinjang.domain.pencil.acquired.model.AcquiredPencil;
 
 public interface AcquiredPencilRepository extends JpaRepository<AcquiredPencil, Long> {
-	List<AcquiredPencil> findAllByMemberOrderByCreatedAtDesc(Member member);
+
+	@Query("SELECT new umc.th.juinjang.api.pencil.service.response.AcquiredPencilResponse(" +
+		"ap.id, ap.content, ap.sharedNoteId, ap.acquiredQuantity, " +
+		"ap.isRead, ap.type, ap.createdAt, sn.buildingName) " +
+		"FROM AcquiredPencil ap " +
+		"LEFT JOIN SharedNote sn ON ap.sharedNoteId = sn.sharedNoteId " +
+		"WHERE ap.member = :member " +
+		"ORDER BY ap.createdAt DESC")
+	List<AcquiredPencilResponse> findAllByMemberWithBuildingNameOrderByCreatedAtDesc(@Param("member") Member member);
 
 	boolean existsByMemberAndIsReadFalse(Member member);
+
 	boolean existsByMember(Member member);
 }


### PR DESCRIPTION
## 작업내용

1. Reward 달성 시에 content 수정 

```java
	private AcquiredPencil createAcquiredPencil(Long sharedNoteId, Member seller, Long price, AcquiredType type) {
		String content = "노트 공유 완료!";
		return AcquiredPencil.create(seller, content, sharedNoteId, price, false, type);
	}
```

2. 얻은 연필목록에서 buildingName 넘기도록 수정 

```java
	@Query("SELECT new umc.th.juinjang.api.pencil.service.response.AcquiredPencilResponse(" +
		"ap.id, ap.content, ap.sharedNoteId, ap.acquiredQuantity, " +
		"ap.isRead, ap.type, ap.createdAt, sn.buildingName) " +
		"FROM AcquiredPencil ap " +
		"LEFT JOIN SharedNote sn ON ap.sharedNoteId = sn.sharedNoteId " +
		"WHERE ap.member = :member " +
		"ORDER BY ap.createdAt DESC")
	List<AcquiredPencilResponse> findAllByMemberWithBuildingNameOrderByCreatedAtDesc(@Param("member") Member member);

```
