### PR TITLE
[fix/#437] 임장 둘러보기 관련 자잘한 버그 fix

### DIFF
--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteQueryService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteQueryService.java
@@ -59,20 +59,25 @@ public class SharedNoteQueryService {
 		SharedNote sharedNote = sharedNoteFinder.findByIdWithNoteAndAddress(sharedNoteId);
 		Limjang limjang = sharedNote.getLimjang();
 
-		boolean isBuyer = usedPencilFinder.existsByMemberAndSharedNoteId(member, sharedNoteId);
+		boolean isBuyerOrOwner = getIsBuyerOrOwner(member, sharedNote);
 
 		long viewCount = getViewCountAndCheckReward(member, sharedNoteId, sharedNote);
 
 		Integer countBuyer = makeBuyerCount(usedPencilFinder.countBySharedNoteId(sharedNoteId));
 		boolean isLiked = likedNoteFinder.existsByMemberAndSharedNote(member, sharedNote);
 
-		if (isBuyer) {
-			return SharedNoteGetResponse.ofPurchased(isBuyer, limjang, limjang.getAddressEntity(), sharedNote,
+		if (isBuyerOrOwner) {
+			return SharedNoteGetResponse.ofPurchased(isBuyerOrOwner, limjang, limjang.getAddressEntity(), sharedNote,
 				sharedNote.getMember(), countBuyer, isLiked, viewCount);
 		} else {
-			return SharedNoteGetResponse.ofNotPurchased(isBuyer, limjang, limjang.getAddressEntity(), sharedNote,
+			return SharedNoteGetResponse.ofNotPurchased(isBuyerOrOwner, limjang, limjang.getAddressEntity(), sharedNote,
 				sharedNote.getMember(), countBuyer, isLiked, viewCount);
 		}
+	}
+
+	private boolean getIsBuyerOrOwner(Member requestMember, SharedNote sharedNote) {
+		return usedPencilFinder.existsByMemberAndSharedNoteId(requestMember, sharedNote.getSharedNoteId()) ||
+			sharedNote.getMember().getMemberId().equals(requestMember.getMemberId());
 	}
 
 	private long getViewCountAndCheckReward(Member member, Long sharedNoteId, SharedNote sharedNote) {

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/response/SharedNoteGetResponse.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/response/SharedNoteGetResponse.java
@@ -62,7 +62,7 @@ public record SharedNoteGetResponse(
 			limjang.getPriceType(),
 			buyerCount,
 			findImagesUrlBySharingStatus(sharedNote.isImageShared(), limjang, 2),
-			address.getFullAddress(),
+			address.getRoadAddress(),
 			address.getShortAddress(),
 			limjang.getLimjangPrice().getPrice(limjang.getPriceType(), limjang.getPurpose()),
 			limjang.getPriceType() == LimjangPriceType.MONTHLY_RENT ? limjang.getLimjangPrice().getMonthlyRent() :
@@ -103,7 +103,7 @@ public record SharedNoteGetResponse(
 			limjang.getPriceType(),
 			buyerCount,
 			findImagesUrlBySharingStatus(sharedNote.isImageShared(), limjang, 3),
-			address.getFullAddress(),
+			address.getRoadAddress(),
 			address.getShortAddress(),
 			limjang.getLimjangPrice().getPrice(limjang.getPriceType(), limjang.getPurpose()),
 			limjang.getPriceType() == LimjangPriceType.MONTHLY_RENT ? limjang.getLimjangPrice().getMonthlyRent() :

--- a/src/main/java/umc/th/juinjang/domain/limjang/model/Address.java
+++ b/src/main/java/umc/th/juinjang/domain/limjang/model/Address.java
@@ -70,7 +70,7 @@ public class Address extends BaseEntity {
 
 	public String getShortAddress() {
 		return Stream.of(sigungo, bname1, bname2)
-			.filter(Objects::nonNull)
+			.filter(s -> s != null && !s.isBlank())
 			.collect(Collectors.joining(" "));
 	}
 

--- a/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteQueryDSLRepositoryImpl.java
+++ b/src/main/java/umc/th/juinjang/domain/note/shared/repository/SharedNoteQueryDSLRepositoryImpl.java
@@ -10,6 +10,7 @@ import static umc.th.juinjang.domain.pencil.used.model.QUsedPencil.*;
 import static umc.th.juinjang.domain.report.model.QReport.*;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -64,9 +65,10 @@ public class SharedNoteQueryDSLRepositoryImpl implements SharedNoteQueryDSLRepos
 			.fetch();
 
 		JPAQuery<Long> countQuery = queryFactory
-			.select(sharedNote.count())
-			.from(sharedNote)
+			.select(sharedNote.count()).from(sharedNote)
 			.join(sharedNote.limjang, limjang)
+			.join(sharedNote.member, member)
+			.join(limjang.limjangPrice, limjangPrice)
 			.join(limjang.addressEntity, address)
 			.leftJoin(limjang.report, report)
 			.where(
@@ -74,9 +76,10 @@ public class SharedNoteQueryDSLRepositoryImpl implements SharedNoteQueryDSLRepos
 				getWhereByPropertyType(propertyType),
 				getWhereByPriceType(priceType),
 				keywordCondition(keyword),
-				sharedNote.deletedAt.isNull()
+				sharedNote.deletedAt.isNull(),
+				limjang.deleted.isFalse()
 			);
-		long totalCount = countQuery.fetchOne();
+		long totalCount = Optional.ofNullable(countQuery.fetchOne()).orElse(0L);
 		return new PageImpl<>(content, pageable, totalCount);
 	}
 


### PR DESCRIPTION
## 작업내용

임장 둘러보기 관련 자잘한 버그 fix

## 상세설명_ & 캡쳐

### 요구사항 미반영 문제들
1. 임장 둘러보기 상세보기에서 도로명 주소 + 상세주소로 리턴되고 있음 -> 도로명 주소만 리턴되도록 변경
2. 현재 임장 주인인 경우에도 임장을 구매할 수 있는 문제가 있음 -> 임장 주인인 경우 isBuyer 필드 true로 리턴
- 아래 코드처럼 구매자인지, 소유자인지 여부도 판별
```java
	private boolean getIsBuyerOrOwner(Member requestMember, SharedNote sharedNote) {
		return usedPencilFinder.existsByMemberAndSharedNoteId(requestMember, sharedNote.getSharedNoteId()) ||
			sharedNote.getMember().getMemberId().equals(requestMember.getMemberId());
	}
```

### 코드상 버그 fix
1. 임장 둘러보기에서 전체 갯수 불일치 문제 fix
- count 쿼리에서 조건을 빠뜨려서 나는 버그인 것을 확인 -> limjang.deleted.isFalse() 추가하여 fix
```java
		JPAQuery<Long> countQuery = queryFactory
			.select(sharedNote.count()).from(sharedNote)
			.join(sharedNote.limjang, limjang)
			.join(sharedNote.member, member)
			.join(limjang.limjangPrice, limjangPrice)
			.join(limjang.addressEntity, address)
			.leftJoin(limjang.report, report)
			.where(
				getBcodesStartsWith(code),
				getWhereByPropertyType(propertyType),
				getWhereByPriceType(priceType),
				keywordCondition(keyword),
				sharedNote.deletedAt.isNull(),
				limjang.deleted.isFalse()
			);
```
2. 임장 상세보기에서 주소에 " "이 한번 더들어가는 문제 
- 해당 필드가 DB에 null이 아닌 " "이 들어간 문제였음. 필터 조건에 추가하여 fix
```java
	public String getShortAddress() {
		return Stream.of(sigungo, bname1, bname2)
			.filter(s -> s != null && !s.isBlank())
			.collect(Collectors.joining(" "));
	}
```