### PR TITLE
🐛 fix: sharedNote 생성시 response에 sharedNoteId 추가

### DIFF
--- a/src/main/java/umc/th/juinjang/api/note/shared/controller/SharedNoteController.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/controller/SharedNoteController.java
@@ -29,6 +29,7 @@ import umc.th.juinjang.api.note.shared.service.SharedNoteQueryService;
 import umc.th.juinjang.api.note.shared.service.response.SharedNoteCheckListAndReviewResponse;
 import umc.th.juinjang.api.note.shared.service.response.SharedNoteExploreGetResponse;
 import umc.th.juinjang.api.note.shared.service.response.SharedNoteGetResponse;
+import umc.th.juinjang.api.note.shared.service.response.SharedNotePostResponse;
 import umc.th.juinjang.api.note.shared.service.response.UserSharedNotesGetResponse;
 import umc.th.juinjang.domain.limjang.model.LimjangPriceType;
 import umc.th.juinjang.domain.limjang.model.LimjangPropertyType;
@@ -67,11 +68,10 @@ public class SharedNoteController {
 
 	@Operation(summary = "공유 노트 생성 API")
 	@PostMapping("/{noteId}")
-	public ApiResponse<Void> uploadSharedNote(@AuthenticationPrincipal Member member,
+	public ApiResponse<SharedNotePostResponse> uploadSharedNote(@AuthenticationPrincipal Member member,
 		@PathVariable("noteId") Long noteId,
 		@RequestBody SharedNotePostRequest request) {
-		sharedNoteCommandService.createSharedNote(member, noteId, request);
-		return ApiResponse.onSuccess(null);
+		return ApiResponse.onSuccess(sharedNoteCommandService.createSharedNote(member, noteId, request));
 	}
 
 	@Operation(summary = "공유 노트 둘러보기 API")

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/SharedNoteCommandService.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import umc.th.juinjang.api.limjang.service.NoteFinder;
 import umc.th.juinjang.api.limjang.service.NoteUpdater;
 import umc.th.juinjang.api.note.shared.controller.request.SharedNotePostRequest;
+import umc.th.juinjang.api.note.shared.service.response.SharedNotePostResponse;
 import umc.th.juinjang.api.pencil.service.AcquiredPencilUpdater;
 import umc.th.juinjang.api.pencil.service.PurchasedPencilUpdater;
 import umc.th.juinjang.api.pencil.service.UsedPencilFinder;
@@ -134,7 +135,7 @@ public class SharedNoteCommandService {
 	}
 
 	@Transactional
-	public void createSharedNote(Member member, Long noteId, SharedNotePostRequest request) {
+	public SharedNotePostResponse createSharedNote(Member member, Long noteId, SharedNotePostRequest request) {
 
 		Limjang limjang = noteFinder.getNoteByIdWhereDeletedIsFalse(noteId);
 		Optional<SharedNote> latestSharedNote = sharedNoteFinder.findLatestByLimjangId(noteId);
@@ -152,12 +153,13 @@ public class SharedNoteCommandService {
 
 		// 공유 저장
 		SharedNote sharedNote = SharedNote.toSharedNote(member, limjang, request, price);
-		sharedNoteUpdater.save(sharedNote);
+		sharedNote = sharedNoteUpdater.save(sharedNote);
 
 		// 보상 처리
 		if (rewardPencilCount > 0) {
 			applyReward(member, limjang, sharedNote.getSharedNoteId(), rewardPencilCount);
 		}
+		return new SharedNotePostResponse(sharedNote.getSharedNoteId());
 	}
 
 	private int calculateReward(Limjang limjang, SharedNotePostRequest request) {

--- a/src/main/java/umc/th/juinjang/api/note/shared/service/response/SharedNotePostResponse.java
+++ b/src/main/java/umc/th/juinjang/api/note/shared/service/response/SharedNotePostResponse.java
@@ -1,0 +1,6 @@
+package umc.th.juinjang.api.note.shared.service.response;
+
+public record SharedNotePostResponse(
+	Long sharedNoteId
+) {
+}


### PR DESCRIPTION
## 작업내용
SharedNote POST API 호출시 Response에 sharedNoteId 추가

## 상세설명_ & 캡쳐
<img width="1637" height="169" alt="image" src="https://github.com/user-attachments/assets/5b6187b0-b760-4113-8333-82bcde2bfde7" />
