### PR TITLE
[fix/#445] 내 임장 노트 조회 response 요소 추가

### DIFF
--- a/src/main/java/umc/th/juinjang/api/limjang/service/NoteQueryServiceV2.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/service/NoteQueryServiceV2.java
@@ -89,7 +89,7 @@ public class NoteQueryServiceV2 {
 	public UserNoteGetResponse findNote(Long noteId) {
 		Limjang note = noteFinder.getNoteByIdWithAddressAndNotePriceWhereDeletedIsFalse(noteId);
 		boolean isShared = sharedNoteFinder.existsByDeletedAtIsNullAndLimjang(note);
-		return UserNoteGetResponse.of(isShared, note);
+		return UserNoteGetResponse.of(isShared, note, note.getAddressEntity());
 	}
 
 	public ChecklistConditionResponse checkLimjangChecklistSatisfaction(Long limjangId) {

--- a/src/main/java/umc/th/juinjang/api/limjang/service/response/UserNoteGetResponse.java
+++ b/src/main/java/umc/th/juinjang/api/limjang/service/response/UserNoteGetResponse.java
@@ -4,6 +4,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import umc.th.juinjang.domain.image.model.Image;
+import umc.th.juinjang.domain.limjang.model.Address;
 import umc.th.juinjang.domain.limjang.model.Limjang;
 import umc.th.juinjang.domain.limjang.model.LimjangPriceType;
 import umc.th.juinjang.domain.limjang.model.LimjangPropertyType;
@@ -22,9 +23,14 @@ public record UserNoteGetResponse(
 	String monthlyRent,
 	String updatedAt,
 	String floor,
-	Integer pyong
+	Integer pyong,
+	String bcode,
+	String sido,
+	String sigungu,
+	String bname1,
+	String bname2
 ) {
-	public static UserNoteGetResponse of(boolean isShared, Limjang note) {
+	public static UserNoteGetResponse of(boolean isShared, Limjang note, Address address) {
 		return new UserNoteGetResponse(
 			isShared,
 			note.getPurpose(),
@@ -32,12 +38,18 @@ public record UserNoteGetResponse(
 			note.getPriceType(),
 			note.getNickname(),
 			note.getImageList().stream().map(Image::getImageUrl).limit(3).toList(),
-			note.getAddressEntity().getRoadAddress(),
-			note.getAddressEntity().getAddressDetail(),
+			address.getRoadAddress(),
+			address.getAddressDetail(),
 			note.getLimjangPrice().getPrice(note.getPriceType(), note.getPurpose()),
 			note.getPriceType() == LimjangPriceType.MONTHLY_RENT ? note.getLimjangPrice().getMonthlyRent() : null,
 			note.getUpdatedAt().format(DateTimeFormatter.ofPattern("yy.MM.dd")),
 			note.getFloor(),
-			note.getPyong());
+			note.getPyong(),
+			address.getBcode(),
+			address.getSido(),
+			address.getSigungo(),
+			address.getBname1(),
+			address.getBname2()
+		);
 	}
 }


### PR DESCRIPTION
## 작업내용

내 임장 노트 조회 response 요소 추가

## 상세설명_ & 캡쳐

- 임장 수정 화면에서도 같은 API를 사용하는데, bcode와 sido 등의 정보도 필요하여 추가했습니다.